### PR TITLE
Docker: MySQL, Dotenv 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/java,intellij+all,intellij+iml,visualstudiocode,visualstudio,kotlin,netbeans,windows,macos,gradle,groovy,redis,vue,vuejs,react,git,gitbook,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=java,intellij+all,intellij+iml,visualstudiocode,visualstudio,kotlin,netbeans,windows,macos,gradle,groovy,redis,vue,vuejs,react,git,gitbook,linux
 
+### .env ###
+.env
+
 ### Git ###
 # Created by git for backups. To disable backups in Git:
 # $ git config --global mergetool.keepBackup false

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,24 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'p6spy:p6spy:3.9.1'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.12.0'
+
 }
 
 tasks.named('test') {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: community-mysql
+    restart: always
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - community-mysql-data:/var/lib/mysql
+    networks:
+      - community-network
+
+volumes:
+  community-mysql-data:
+
+networks:
+  community-network:

--- a/src/main/java/com/community/soap/SoapApplication.java
+++ b/src/main/java/com/community/soap/SoapApplication.java
@@ -1,5 +1,6 @@
 package com.community.soap;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,7 +8,17 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class SoapApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(SoapApplication.class, args);
+        // .env 파일 로드 (resources 기준 경로로)
+        Dotenv dotenv = Dotenv.configure()
+                .directory("src/main/resources") // 또는 .env 의 실제 경로
+                .ignoreIfMissing()
+                .load();
+
+        // 시스템 프로퍼티에 등록 (Spring 이 인식할 수 있도록)
+        dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(), entry.getValue()));
+
+
+        SpringApplication.run(SoapApplication.class, args);
 	}
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=soap

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  application:
+    name: community-service
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${RDS_USERNAME:local}
+    password: ${RDS_PASSWORD:local}
+    url: jdbc:mysql://${RDS_ENDPOINT:localhost}:3307/community?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&useSSL=false&rewriteBatchedStatements=true
+
+  jpa:
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+        open-in-view: false


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- 도커 컴포즈로 MySQL 8.0 실행할 수 있도록 간단하게 작성
- Dotenv를 통해 docker-compose.yml, application.yml의 각 .env 파일이 적용할 수 있도록 추가
- .gitignore에 .env 파일을 제외하도록 작성

## 🔍 관련 이슈
- Closes #9 

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * Docker Compose로 MySQL 서비스 추가(영구 볼륨 및 전용 네트워크 포함).
  * 애플리케이션이 .env 값을 런타임에 로드하여 환경 기반 설정 지원.
  * application.yml 도입: 애플리케이션 이름 설정, MySQL 데이터소스/포트 구성, JPA/Hibernate 로깅 및 DDL 전략 적용.

* 작업(Chores)
  * .gitignore에 .env 무시 규칙 추가.
  * 빌드 의존성 확장: JPA, 검증, MySQL 드라이버, dotenv, 쿼리 로깅 관련 라이브러리 및 테스트 스코프 Lombok 추가.
  * 기존 application.properties의 앱 이름 설정 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->