### PR TITLE
User: CRUD 구현하기

### DIFF
--- a/src/main/java/com/community/soap/common/config/snowflakeConfig.java
+++ b/src/main/java/com/community/soap/common/config/snowflakeConfig.java
@@ -1,0 +1,14 @@
+package com.community.soap.common.config;
+
+import com.community.soap.common.snowflake.Snowflake;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class snowflakeConfig {
+
+    @Bean
+    public Snowflake snowflake() {
+        return new Snowflake();
+    }
+}

--- a/src/main/java/com/community/soap/user/application/UserService.java
+++ b/src/main/java/com/community/soap/user/application/UserService.java
@@ -1,0 +1,74 @@
+package com.community.soap.user.application;
+
+import com.community.soap.common.snowflake.Snowflake;
+import com.community.soap.user.application.request.SignInRequest;
+import com.community.soap.user.application.request.SignUpRequest;
+import com.community.soap.user.application.response.MyPageResponse;
+import com.community.soap.user.application.response.SignInResponse;
+import com.community.soap.user.application.response.SignUpResponse;
+import com.community.soap.user.domain.entity.User;
+import com.community.soap.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService implements UserUseCase {
+
+    private final UserRepository userRepository;
+    private final Snowflake snowflake;
+
+    private User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "User with email " + email + " not found"));
+    }
+
+    private User findByUserId(Long userId) {
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "User with id " + userId + " not found"));
+    }
+
+    @Transactional
+    @Override
+    public SignUpResponse signup(SignUpRequest request) {
+        User register = User.register(
+                snowflake.nextId(),
+                request.email(),
+                request.password()
+        );
+
+        userRepository.save(register);
+
+        return SignUpResponse.from(register);
+    }
+
+    @Transactional
+    @Override
+    public SignInResponse signIn(SignInRequest request) {
+        User byEmail = findByEmail(request.email());
+
+        if (!byEmail.getPassword().equals(request.password())) {
+            throw new IllegalStateException("Passwords don't match");
+        }
+
+        return SignInResponse.from(byEmail);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public MyPageResponse myPage(Long userId) {
+        User byUserId = findByUserId(userId);
+
+        return MyPageResponse.from(byUserId);
+    }
+
+    @Transactional
+    @Override
+    public void deleteUser(Long userId) {
+        User byUserId = findByUserId(userId);
+        byUserId.delete(userId);
+    }
+}

--- a/src/main/java/com/community/soap/user/application/UserUseCase.java
+++ b/src/main/java/com/community/soap/user/application/UserUseCase.java
@@ -1,0 +1,18 @@
+package com.community.soap.user.application;
+
+import com.community.soap.user.application.request.SignInRequest;
+import com.community.soap.user.application.request.SignUpRequest;
+import com.community.soap.user.application.response.MyPageResponse;
+import com.community.soap.user.application.response.SignInResponse;
+import com.community.soap.user.application.response.SignUpResponse;
+
+public interface UserUseCase {
+
+    SignUpResponse signup(SignUpRequest request);
+
+    SignInResponse signIn(SignInRequest request);
+
+    MyPageResponse myPage(Long userId);
+
+    void deleteUser(Long userId);
+}

--- a/src/main/java/com/community/soap/user/application/request/SignInRequest.java
+++ b/src/main/java/com/community/soap/user/application/request/SignInRequest.java
@@ -1,0 +1,22 @@
+package com.community.soap.user.application.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SignInRequest(
+        @NotBlank(message = "이메일: 이메일은 필수입니다.")
+        @Email(message = "이메일: 유효하지 않은 이메일 형식입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호: 비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}|\\[\\]:\";'<>?,./]).{8,}$",
+                message = "비밀번호: 비밀번호는 최소 8자 이상이며, 영문자, 숫자, 특수문자를 포함해야 합니다."
+        )
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        String password
+) {
+
+}

--- a/src/main/java/com/community/soap/user/application/request/SignUpRequest.java
+++ b/src/main/java/com/community/soap/user/application/request/SignUpRequest.java
@@ -1,0 +1,29 @@
+package com.community.soap.user.application.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SignUpRequest(
+        @NotBlank(message = "이메일: 이메일은 필수입니다.")
+        @Email(message = "이메일: 유효하지 않은 이메일 형식입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호: 비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}|\\[\\]:\";'<>?,./]).{8,}$",
+                message = "비밀번호: 비밀번호는 최소 8자 이상이며, 영문자, 숫자, 특수문자를 포함해야 합니다."
+        )
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        String password,
+
+        @NotBlank(message = "닉네임: 닉네임은 필수입니다.")
+        @Pattern(
+                regexp = "^[A-Za-z0-9가-힣!@#$%^&*()_+\\-={}|\\[\\]:\";'<>?,./]{1,12}$",
+                message = "닉네임: 닉네임은 12자 이내이며, 영문 대소문자, 한글, 숫자, 특수기호만 사용할 수 있습니다."
+        )
+        String nickname
+) {
+
+}

--- a/src/main/java/com/community/soap/user/application/response/MyPageResponse.java
+++ b/src/main/java/com/community/soap/user/application/response/MyPageResponse.java
@@ -1,0 +1,24 @@
+package com.community.soap.user.application.response;
+
+import com.community.soap.user.domain.entity.User;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record MyPageResponse(
+        String email,
+        String nickname,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static MyPageResponse from(User byUserId) {
+        return MyPageResponse.builder()
+                .email(byUserId.getEmail())
+                .nickname(byUserId.getNickname())
+                .createdAt(byUserId.getCreatedAt())
+                .updatedAt(byUserId.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/community/soap/user/application/response/SignInResponse.java
+++ b/src/main/java/com/community/soap/user/application/response/SignInResponse.java
@@ -1,0 +1,24 @@
+package com.community.soap.user.application.response;
+
+import com.community.soap.user.domain.entity.User;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record SignInResponse(
+        String email,
+        String nickname,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static SignInResponse from(User byEmail) {
+        return SignInResponse.builder()
+                .email(byEmail.getEmail())
+                .nickname(byEmail.getNickname())
+                .createdAt(byEmail.getCreatedAt())
+                .updatedAt(byEmail.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/community/soap/user/application/response/SignUpResponse.java
+++ b/src/main/java/com/community/soap/user/application/response/SignUpResponse.java
@@ -1,0 +1,26 @@
+package com.community.soap.user.application.response;
+
+import com.community.soap.user.domain.entity.User;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record SignUpResponse(
+        Long userId,
+        String email,
+        String nickname,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static SignUpResponse from(User register) {
+        return SignUpResponse.builder()
+                .userId(register.getUserId())
+                .email(register.getEmail())
+                .nickname(register.getNickname())
+                .createdAt(register.getCreatedAt())
+                .updatedAt(register.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/community/soap/user/domain/entity/User.java
+++ b/src/main/java/com/community/soap/user/domain/entity/User.java
@@ -1,0 +1,72 @@
+package com.community.soap.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter(AccessLevel.PUBLIC)
+@Table(name = "s_user")
+@Entity
+public class User {
+
+    @Id
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(name = "email", nullable = false, length = 100)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 512)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, length = 12)
+    private String nickname;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = Boolean.FALSE;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    private User(Long userId, String email, String password) {
+        this.userId = userId;
+        this.email = email;
+        this.password = password;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = null;
+    }
+
+    public static User register(Long userId, String email, String password) {
+        return new User(userId, email, password);
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+        update(userId);
+    }
+
+    public void delete(Long userId) {
+        this.isDeleted = Boolean.TRUE;
+        update(userId);
+    }
+
+    private void update(Long userId) {
+        this.userId = userId;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/java/com/community/soap/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/community/soap/user/domain/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.community.soap.user.domain.repository;
+
+import com.community.soap.user.domain.entity.User;
+import java.util.Optional;
+
+public interface UserRepository {
+
+    Optional<User> findByEmail(String email);
+
+    User save(User user);
+
+    Optional<User> findByUserId(Long userId);
+}

--- a/src/main/java/com/community/soap/user/persistence/JpaUserRepository.java
+++ b/src/main/java/com/community/soap/user/persistence/JpaUserRepository.java
@@ -1,0 +1,9 @@
+package com.community.soap.user.persistence;
+
+import com.community.soap.user.domain.entity.User;
+import com.community.soap.user.domain.repository.UserRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserRepository extends JpaRepository<User, Long>, UserRepository {
+
+}

--- a/src/main/java/com/community/soap/user/presentation/UserController.java
+++ b/src/main/java/com/community/soap/user/presentation/UserController.java
@@ -1,0 +1,69 @@
+package com.community.soap.user.presentation;
+
+import com.community.soap.user.application.UserUseCase;
+import com.community.soap.user.application.request.SignInRequest;
+import com.community.soap.user.application.request.SignUpRequest;
+import com.community.soap.user.application.response.MyPageResponse;
+import com.community.soap.user.application.response.SignInResponse;
+import com.community.soap.user.application.response.SignUpResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@RestController
+public class UserController {
+
+    private final UserUseCase userUseCase;
+
+    @PostMapping("/auth/signup")
+    public ResponseEntity<SignUpResponse> signup(@RequestBody @Valid SignUpRequest request) {
+        SignUpResponse response = userUseCase.signup(request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    @PostMapping("/auth/sign-in")
+    public ResponseEntity<SignInResponse> signIn(
+            @RequestBody @Valid SignInRequest request
+    ) {
+        SignInResponse response = userUseCase.signIn(request);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<MyPageResponse> myPage(
+            @PathVariable(name = "userId") Long userId
+    ) {
+        MyPageResponse response = userUseCase.myPage(userId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @DeleteMapping("/user/{userId}")
+    public ResponseEntity<Void> deleteUser(
+            @PathVariable(name = "userId") Long userId
+    ) {
+        userUseCase.deleteUser(userId);
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+}

--- a/src/test/java/com/community/soap/user/application/UserServiceTest.java
+++ b/src/test/java/com/community/soap/user/application/UserServiceTest.java
@@ -1,0 +1,177 @@
+package com.community.soap.user.application;
+
+
+import com.community.soap.common.snowflake.Snowflake;
+import com.community.soap.user.application.request.SignInRequest;
+import com.community.soap.user.application.request.SignUpRequest;
+import com.community.soap.user.application.response.MyPageResponse;
+import com.community.soap.user.application.response.SignInResponse;
+import com.community.soap.user.application.response.SignUpResponse;
+import com.community.soap.user.domain.entity.User;
+import com.community.soap.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Snowflake snowflake;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Nested
+    @DisplayName("signup()")
+    class SignupTest {
+
+        @Test
+        @DisplayName("정상 가입 시 저장되고 응답을 반환한다")
+        void signup_success() {
+            // given
+            long generatedId = 1234L;
+            given(snowflake.nextId()).willReturn(generatedId);
+
+            SignUpRequest req = new SignUpRequest(
+                    "foo@bar.com",
+                    "P@ssw0rd!",
+                    "닉네임"
+            );
+
+            // 저장되는 엔티티를 검증하기 위해 캡쳐
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            given(userRepository.save(userCaptor.capture()))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            SignUpResponse res = userService.signup(req);
+
+            // then
+            User saved = userCaptor.getValue();
+            assertThat(saved.getUserId()).isEqualTo(generatedId);
+            assertThat(saved.getEmail()).isEqualTo("foo@bar.com");
+            assertThat(saved.getPassword()).isEqualTo("P@ssw0rd!");
+
+            assertThat(res).isNotNull();
+            assertThat(res.userId()).isEqualTo(generatedId);
+
+            then(userRepository).should(times(1)).save(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("signIn()")
+    class SignInTest {
+
+        @Test
+        @DisplayName("이메일/비밀번호가 맞으면 성공")
+        void signIn_success() {
+            // given
+            User user = User.register(100L, "foo@bar.com", "P@ssw0rd!");
+            given(userRepository.findByEmail("foo@bar.com")).willReturn(Optional.of(user));
+
+            SignInRequest req = new SignInRequest("foo@bar.com", "P@ssw0rd!");
+
+            // when
+            SignInResponse res = userService.signIn(req);
+
+            // then
+            assertThat(res).isNotNull();
+            assertThat(res.email()).isEqualTo("foo@bar.com");
+        }
+
+        @Test
+        @DisplayName("비밀번호가 틀리면 예외")
+        void signIn_wrongPassword() {
+            // given
+            User user = User.register(100L, "foo@bar.com", "correct!");
+            given(userRepository.findByEmail("foo@bar.com")).willReturn(Optional.of(user));
+
+            SignInRequest req = new SignInRequest("foo@bar.com", "wrong!");
+
+            // when & then
+            assertThatThrownBy(() -> userService.signIn(req))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Passwords don't match");
+        }
+
+        @Test
+        @DisplayName("이메일을 못 찾으면 예외")
+        void signIn_emailNotFound() {
+            // given
+            given(userRepository.findByEmail("no@no.com")).willReturn(Optional.empty());
+            SignInRequest req = new SignInRequest("no@no.com", "any");
+
+            // when & then
+            assertThatThrownBy(() -> userService.signIn(req))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("User with email no@no.com not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("myPage()")
+    class MyPageTest {
+
+        @Test
+        @DisplayName("사용자 ID로 조회 성공")
+        void myPage_success() {
+            // given
+            User user = User.register(777L, "me@site.com", "pw");
+            given(userRepository.findByUserId(777L)).willReturn(Optional.of(user));
+
+            // when
+            MyPageResponse res = userService.myPage(777L);
+
+            // then
+            assertThat(res).isNotNull();
+            assertThat(res.email()).isEqualTo("me@site.com");
+        }
+
+        @Test
+        @DisplayName("사용자 ID를 못 찾으면 예외")
+        void myPage_notFound() {
+            // given
+            given(userRepository.findByUserId(1L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userService.myPage(1L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("User with id 1 not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteUser()")
+    class DeleteUserTest {
+
+        @Test
+        @DisplayName("엔티티의 delete(userId)가 호출된다")
+        void deleteUser_callsDomainDelete() {
+            // given
+            // delete(userId) 동작을 눈으로 확인하기 어려우면, 스파이 또는 가짜 엔티티를 써서 플래그를 세우는 방법이 좋음
+            User user = Mockito.spy(User.register(55L, "x@y.com", "pw"));
+            given(userRepository.findByUserId(55L)).willReturn(Optional.of(user));
+
+            // when
+            userService.deleteUser(55L);
+
+            // then
+            // 도메인 메서드가 호출됐는지 확인
+            Mockito.verify(user, times(1)).delete(55L);
+        }
+    }
+}


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- snowflake를 Bean 주입
- 간단한 회원 CRUD 구현

## 🔍 관련 이슈
- Closes #13

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 회원가입/로그인 API 추가: POST /api/v1/auth/signup, POST /api/v1/auth/sign-in
  - 마이페이지 조회: GET /api/v1/user/{userId}
  - 회원 삭제: DELETE /api/v1/user/{userId}
  - 요청 검증 강화: 이메일 형식, 비밀번호 규칙(8+자·영문/숫자/특수문자), 닉네임 규칙
  - 응답에 생성/수정 시각 포함, 비밀번호는 응답에서 제외
  - 표준 상태코드 사용: 201 Created, 200 OK, 204 No Content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->