### PR TITLE
User: Spring Security를 대체한 보안 구성

### DIFF
--- a/src/main/java/com/community/soap/common/aop/Permission.java
+++ b/src/main/java/com/community/soap/common/aop/Permission.java
@@ -1,0 +1,17 @@
+package com.community.soap.common.aop;
+
+import com.community.soap.user.domain.entity.UserRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Permission {
+    UserRole[] value() default {
+            UserRole.ADMIN,
+            UserRole.MANAGER,
+            UserRole.USER
+    };
+}

--- a/src/main/java/com/community/soap/common/aop/PermissionAspect.java
+++ b/src/main/java/com/community/soap/common/aop/PermissionAspect.java
@@ -1,0 +1,65 @@
+package com.community.soap.common.aop;
+
+import static com.community.soap.common.util.AuthKeys.ATTR_USER_ROLE;
+import static com.community.soap.common.util.AuthKeys.HDR_USER_ROLE;
+
+import com.community.soap.common.exception.AppException;
+import com.community.soap.common.exception.CommonErrorCode;
+import com.community.soap.user.domain.entity.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+
+@Slf4j(topic = "PermissionAspect")
+@Aspect
+@Component
+public class PermissionAspect {
+
+    @Before("@annotation(permission)")
+    public void permission(JoinPoint joinPoint, Permission permission) {
+        Set<UserRole> allowed = Arrays.stream(permission.value()).collect(Collectors.toSet());
+        UserRole current = resolveCurrentUserRole();
+
+        if (!allowed.contains(current)) {
+            log.info("권한 거부: 현재 역할={}, 허용 역할={}", current, allowed);
+            throw new AppException(CommonErrorCode.FORBIDDEN);
+        }
+    }
+
+    private UserRole resolveCurrentUserRole() {
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs == null) {
+            log.warn("ServletRequestAttributes is null");
+            throw new AppException(CommonErrorCode.INVALID_HEADER);
+        }
+        HttpServletRequest req = attrs.getRequest();
+
+        Object roleAttr = req.getAttribute(ATTR_USER_ROLE);
+        if (roleAttr instanceof UserRole) {
+            return (UserRole) roleAttr;
+        }
+
+        String roleHeader = req.getHeader(HDR_USER_ROLE);
+        if (roleHeader == null || roleHeader.isBlank()) {
+            log.warn("역할 헤더({}) 없음", HDR_USER_ROLE);
+            throw new AppException(CommonErrorCode.INVALID_HEADER);
+        }
+
+        try {
+            return UserRole.valueOf(roleHeader.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("역할 파싱 실패: '{}'", roleHeader);
+            throw new AppException(CommonErrorCode.INVALID_HEADER);
+        }
+    }
+}

--- a/src/main/java/com/community/soap/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/community/soap/common/exception/CommonErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰 입니다."),
+    INVALID_ROLE_BY_TOKEN(HttpStatus.BAD_REQUEST, "토큰 안의 권한이 유효하지 않습니다."),
 
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
 
@@ -16,7 +18,9 @@ public enum CommonErrorCode implements ErrorCode {
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
 
-    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    INVALID_HEADER(HttpStatus.BAD_REQUEST, "잘못된 헤더 정보입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/community/soap/common/filter/ExceptionHandlingFilter.java
+++ b/src/main/java/com/community/soap/common/filter/ExceptionHandlingFilter.java
@@ -1,0 +1,135 @@
+package com.community.soap.common.filter;
+
+
+import com.community.soap.common.exception.AppException;
+import com.community.soap.common.exception.CommonErrorCode;
+import com.community.soap.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * - 서블릿/필터 레이어에서 발생한 예외를 JSON 표준 응답으로 변환
+ * - JwtAuthenticationFilter 같은 하위 필터가 던진 AppException을 여기서 마무리
+ * - 컨트롤러 레이어 예외는 @RestControllerAdvice가 우선 처리하되, 바깥으로 나오면 이 필터가 최종 방어
+ */
+@Slf4j(topic = "ExceptionHandlingFilter")
+@RequiredArgsConstructor
+public class ExceptionHandlingFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        // 서블릿 ERROR 디스패치 단계에서 중복 처리 방지
+        return true;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AppException ex) {
+            writeAppError(response, request, ex);
+        } catch (Exception ex) {
+            log.error("Unhandled exception", ex);
+            writeGenericError(response, request);
+        }
+    }
+
+    private void writeAppError(HttpServletResponse resp, HttpServletRequest req, AppException ex)
+            throws IOException {
+        if (resp.isCommitted()) {
+            return;
+        }
+
+        ErrorCode code = ex.getErrorCode(); // 인터페이스여도 OK
+        HttpStatus status = (code != null && code.getStatus() != null)
+                ? code.getStatus()
+                : HttpStatus.BAD_REQUEST;
+
+        String message = (code != null && StringUtils.hasText(code.getMessage()))
+                ? code.getMessage()
+                : (StringUtils.hasText(ex.getMessage()) ? ex.getMessage()
+                        : status.getReasonPhrase());
+
+        logAtProperLevel(code, ex);
+
+        String codeName = (code instanceof Enum<?> e) ? e.name()
+                : (code != null ? code.getClass().getSimpleName() : "APP_ERROR");
+
+        resp.resetBuffer();
+        resp.setStatus(status.value());
+        resp.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> body = Map.of(
+                "timestamp", OffsetDateTime.now().toString(),
+                "status", status.value(),
+                "error", status.getReasonPhrase(),
+                "code", codeName,
+                "message", message,
+                "path", req.getRequestURI()
+        );
+        objectMapper.writeValue(resp.getWriter(), body);
+        resp.flushBuffer();
+    }
+
+    private void writeGenericError(HttpServletResponse resp, HttpServletRequest req)
+            throws IOException {
+        if (resp.isCommitted()) {
+            return;
+        }
+
+        HttpStatus status = CommonErrorCode.INTERNAL_SERVER_ERROR.getStatus();
+        String message = CommonErrorCode.INTERNAL_SERVER_ERROR.getMessage();
+
+        resp.resetBuffer();
+        resp.setStatus(status.value());
+        resp.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> body = Map.of(
+                "timestamp", OffsetDateTime.now().toString(),
+                "status", status.value(),
+                "error", status.getReasonPhrase(),
+                "code", CommonErrorCode.INTERNAL_SERVER_ERROR.name(),
+                "message", message,
+                "path", req.getRequestURI()
+        );
+        objectMapper.writeValue(resp.getWriter(), body);
+        resp.flushBuffer();
+    }
+
+    private void logAtProperLevel(ErrorCode code, AppException ex) {
+        HttpStatus status = (code != null) ? code.getStatus() : null;
+        if (status == null) {
+            log.error("AppException without status", ex);
+            return;
+        }
+        if (status.is4xxClientError()) {
+            // 인증/권한/요청 오류 등 클라이언트계열 → warn
+            log.warn("Handled AppException: {} ({})", codeName(code), status, ex);
+        } else {
+            // 서버 오류 → error
+            log.error("Handled AppException: {} ({})", codeName(code), status, ex);
+        }
+    }
+
+    private String codeName(ErrorCode code) {
+        return (code instanceof Enum<?> e) ? e.name()
+                : (code != null ? code.getClass().getSimpleName() : "APP_ERROR");
+    }
+}

--- a/src/main/java/com/community/soap/common/filter/FilterConfig.java
+++ b/src/main/java/com/community/soap/common/filter/FilterConfig.java
@@ -1,0 +1,35 @@
+package com.community.soap.common.filter;
+
+import com.community.soap.common.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    private static final int ORDER_EXCEPTION = 1; // 맨 앞
+    private static final int ORDER_JWT = 2;       // 그 다음
+
+    @Bean
+    public FilterRegistrationBean<ExceptionHandlingFilter> exceptionFilter(ObjectMapper om) {
+        FilterRegistrationBean<ExceptionHandlingFilter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(new ExceptionHandlingFilter(om));
+        reg.addUrlPatterns("/*");
+        reg.setOrder(ORDER_EXCEPTION);
+        return reg;
+    }
+
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtFilter(
+            JwtProvider jwtProvider,
+            JwtFilterProperties props
+    ) {
+        FilterRegistrationBean<JwtAuthenticationFilter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(new JwtAuthenticationFilter(jwtProvider, props));
+        reg.addUrlPatterns("/*");
+        reg.setOrder(ORDER_JWT);
+        return reg;
+    }
+}

--- a/src/main/java/com/community/soap/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/community/soap/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,154 @@
+package com.community.soap.common.filter;
+
+import static com.community.soap.common.util.AuthKeys.ATTR_USER_ID;
+import static com.community.soap.common.util.AuthKeys.ATTR_USER_ROLE;
+
+import com.community.soap.common.exception.AppException;
+import com.community.soap.common.exception.CommonErrorCode;
+import com.community.soap.common.jwt.JwtProvider;
+import com.community.soap.user.domain.entity.UserRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.PathContainer;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+/**
+ * - excludePaths, excludeMethods 기반으로 인증 제외
+ * - Authorization 헤더의 Bearer 토큰 또는 쿠키에서 액세스 토큰 추출
+ * - 토큰에서 userId/role 파싱 후 request attribute 로 저장
+ * - 예외는 던지고, 상위 ExceptionHandlingFilter 가 처리
+ */
+@Slf4j(topic = "JwtAuthenticationFilter")
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final JwtFilterProperties props;
+    private final List<PathPattern> excludePatterns;
+    private final PathPatternParser parser = PathPatternParser.defaultInstance;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider, JwtFilterProperties props) {
+        this.jwtProvider = Objects.requireNonNull(jwtProvider);
+        this.props = Objects.requireNonNull(props);
+        this.excludePatterns = props.getExcludePaths().stream()
+                .flatMap(this::expandPatternVariants)
+                .map(parser::parse)
+                .toList();
+    }
+
+    /**
+     * "/**"의 base, 트레일링 슬래시 제거 변형을 함께 등록해 오탐/미탐을 방지
+     */
+    private Stream<String> expandPatternVariants(String raw) {
+        Stream<String> s = Stream.of(raw);
+        if (raw.endsWith("/**")) {
+            s = Stream.concat(s, Stream.of(raw.substring(0, raw.length() - 3)));
+        }
+        if (raw.endsWith("/") && raw.length() > 1) {
+            s = Stream.concat(s, Stream.of(raw.substring(0, raw.length() - 1)));
+        }
+        return s.distinct();
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // 1) 메서드 제외 (기본 OPTIONS)
+        if (props.getExcludeMethods().stream()
+                .anyMatch(m -> m.equalsIgnoreCase(request.getMethod()))) {
+            return true;
+        }
+        // 2) 경로 제외
+        String stripped = stripContextPath(request.getRequestURI(), request.getContextPath());
+        PathContainer container = PathContainer.parsePath(stripped);
+        return excludePatterns.stream().anyMatch(p -> p.matches(container));
+    }
+
+    private String stripContextPath(String uri, String ctx) {
+        if (!StringUtils.hasLength(ctx)) {
+            return uri;
+        }
+        return uri.startsWith(ctx) ? uri.substring(ctx.length()) : uri;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 여기까지 왔다는 건 shouldNotFilter=false → 인증 필요
+        String accessToken = resolveAccessToken(request);
+        if (!StringUtils.hasText(accessToken)) {
+            throw new AppException(CommonErrorCode.INVALID_HEADER); // Authorization/Cookie 둘 다 없음
+        }
+
+        try {
+            Long userId = jwtProvider.getUserId(accessToken);
+            String roleStr = jwtProvider.getUserRole(accessToken);
+
+            if (userId == null || !StringUtils.hasText(roleStr)) {
+                throw new AppException(CommonErrorCode.INVALID_TOKEN);
+            }
+
+            UserRole role;
+            try {
+                role = UserRole.valueOf(roleStr.trim().toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw new AppException(CommonErrorCode.INVALID_ROLE_BY_TOKEN);
+            }
+
+            // 컨트롤러/리졸버/Aspect에서 공통으로 쓰는 키로 저장
+            request.setAttribute(ATTR_USER_ID, userId);
+            request.setAttribute(ATTR_USER_ROLE, role);
+
+        } catch (AppException e) {
+            // AppException은 그대로 전파 (ExceptionHandlingFilter가 응답 작성)
+            throw e;
+        } catch (Exception e) {
+            // 그 외는 일반 토큰 오류로 통일
+            throw new AppException(CommonErrorCode.INVALID_TOKEN);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Authorization 헤더(Bearer …) 우선, 없으면 쿠키(props.accessTokenCookie)에서 조회. "Bearer" 접두사는 대소문자 무시 +
+     * 앞뒤 공백 허용.
+     */
+    private String resolveAccessToken(HttpServletRequest request) {
+        String auth = request.getHeader("Authorization");
+        if (StringUtils.hasText(auth)) {
+            String candidate = auth.trim();
+            // "Bearer " 접두어 대소문자 무시
+            if (candidate.regionMatches(true, 0, "Bearer ", 0, 7)) {
+                return candidate.substring(7).trim();
+            }
+            // 접두어가 없으면 아예 토큰으로 보지 않고 INVALID_TOKEN 처리하도록 null 반환
+            return null;
+        }
+
+        // 헤더가 없다면 쿠키 fallback
+        String cookieName = props.getAccessTokenCookie();
+        if (request.getCookies() != null && StringUtils.hasText(cookieName)) {
+            for (Cookie c : request.getCookies()) {
+                if (cookieName.equals(c.getName()) && StringUtils.hasText(c.getValue())) {
+                    return c.getValue().trim();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/community/soap/common/filter/JwtFilterProperties.java
+++ b/src/main/java/com/community/soap/common/filter/JwtFilterProperties.java
@@ -1,0 +1,32 @@
+package com.community.soap.common.filter;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "security.jwt-filter")
+public class JwtFilterProperties {
+
+    /**
+     * 인증 제외 경로 (PathPattern 문법, 예: /api/public/**)
+     */
+    private List<String> excludePaths = new ArrayList<>();
+
+    /**
+     * 인증 제외 HTTP 메서드 (예: [OPTIONS, GET] 등)
+     */
+    private List<String> excludeMethods = List.of("OPTIONS");
+
+    /**
+     * 토큰을 쿠키로도 받을 때의 쿠키명
+     */
+    private boolean cookieFallbackEnabled = false; // 기본 꺼짐
+    private String accessTokenCookie = "ACCESS_TOKEN";
+}

--- a/src/main/java/com/community/soap/common/resolver/CurrentUser.java
+++ b/src/main/java/com/community/soap/common/resolver/CurrentUser.java
@@ -1,0 +1,12 @@
+package com.community.soap.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface CurrentUser {
+
+}

--- a/src/main/java/com/community/soap/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/community/soap/common/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,122 @@
+package com.community.soap.common.resolver;
+
+import com.community.soap.common.exception.AppException;
+import com.community.soap.common.exception.CommonErrorCode;
+import com.community.soap.common.util.AuthKeys;
+import com.community.soap.user.domain.entity.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j(topic = "CurrentUserArgumentResolver")
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && CurrentUserInfo.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        // 1) attribute 우선 (필터가 타입 세이프로 넣어준 경우)
+        Object idAttr = request.getAttribute(AuthKeys.ATTR_USER_ID);
+        Object roleAttr = request.getAttribute(AuthKeys.ATTR_USER_ROLE);
+
+        Long userId = coerceUserId(idAttr);
+        UserRole userRole = coerceUserRole(roleAttr);
+
+        // 2) attribute가 없으면 header fallback
+        if (userId == null) {
+            userId = parseUserIdHeader(request.getHeader(AuthKeys.HDR_USER_ID));
+        }
+        if (userRole == null) {
+            userRole = parseUserRoleHeader(request.getHeader(AuthKeys.HDR_USER_ROLE));
+        }
+
+        if (userId == null || userRole == null) {
+            // 인증 정보 자체가 없음 → 401
+            throw new AppException(CommonErrorCode.UNAUTHORIZED);
+        }
+
+        try {
+            return CurrentUserInfo.of(userId, userRole);
+        } catch (IllegalArgumentException e) {
+            // 포맷 자체가 잘못됨 → 400
+            throw new AppException(CommonErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private Long coerceUserId(Object v) {
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof Long l) {
+            return l;
+        }
+        if (v instanceof Integer i) {
+            return i.longValue();
+        }
+        if (v instanceof String s) {
+            try {
+                return Long.parseLong(s.trim());
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private UserRole coerceUserRole(Object v) {
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof UserRole r) {
+            return r;
+        }
+        if (v instanceof String s) {
+            return toUserRole(s);
+        }
+        return null;
+    }
+
+    private Long parseUserIdHeader(String headerVal) {
+        if (headerVal == null || headerVal.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(headerVal.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private UserRole parseUserRoleHeader(String headerVal) {
+        if (headerVal == null || headerVal.isBlank()) {
+            return null;
+        }
+        return toUserRole(headerVal);
+    }
+
+    private UserRole toUserRole(String s) {
+        try {
+            return UserRole.valueOf(s.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            // 포맷 오류는 호출부에서 400 처리
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/community/soap/common/resolver/CurrentUserInfo.java
+++ b/src/main/java/com/community/soap/common/resolver/CurrentUserInfo.java
@@ -1,0 +1,14 @@
+package com.community.soap.common.resolver;
+
+
+import com.community.soap.user.domain.entity.UserRole;
+
+public record CurrentUserInfo(
+        Long userId,
+        UserRole userRole
+) {
+
+    public static CurrentUserInfo of(Long userId, UserRole userRole) {
+        return new CurrentUserInfo(userId, userRole);
+    }
+}

--- a/src/main/java/com/community/soap/common/resolver/WebConfig.java
+++ b/src/main/java/com/community/soap/common/resolver/WebConfig.java
@@ -1,0 +1,19 @@
+package com.community.soap.common.resolver;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/community/soap/common/util/AuthKeys.java
+++ b/src/main/java/com/community/soap/common/util/AuthKeys.java
@@ -1,0 +1,14 @@
+package com.community.soap.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AuthKeys {
+
+    public static final String ATTR_USER_ID  = "X_USER_ID";
+    public static final String ATTR_USER_ROLE = "X_USER_ROLE";
+
+    public static final String HDR_USER_ID   = "X-USER-ID";
+    public static final String HDR_USER_ROLE = "X-USER-ROLE";
+}

--- a/src/main/java/com/community/soap/user/application/UserService.java
+++ b/src/main/java/com/community/soap/user/application/UserService.java
@@ -191,7 +191,7 @@ public class UserService implements UserUseCase {
 
     @Transactional(readOnly = true)
     @Override
-    public MyPageResponse myPage(Long userId) {
+    public MyPageResponse me(Long userId) {
         User byUserId = findUserById(userId);
 
         return MyPageResponse.from(byUserId);

--- a/src/main/java/com/community/soap/user/application/UserUseCase.java
+++ b/src/main/java/com/community/soap/user/application/UserUseCase.java
@@ -12,7 +12,7 @@ public interface UserUseCase {
 
     SignInResponse signIn(SignInRequest request);
 
-    MyPageResponse myPage(Long userId);
+    MyPageResponse me(Long userId);
 
     void deleteUser(Long userId);
 

--- a/src/main/java/com/community/soap/user/presentation/UserController.java
+++ b/src/main/java/com/community/soap/user/presentation/UserController.java
@@ -1,13 +1,18 @@
 package com.community.soap.user.presentation;
 
+import com.community.soap.common.aop.Permission;
+import com.community.soap.common.resolver.CurrentUser;
+import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.user.application.UserUseCase;
 import com.community.soap.user.application.response.MyPageResponse;
+import com.community.soap.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,15 +24,25 @@ public class UserController {
     private final UserUseCase userUseCase;
 
     @GetMapping("/{userId}")
-    public ResponseEntity<MyPageResponse> myPage(
+    @Permission(value = {UserRole.ADMIN, UserRole.MANAGER, UserRole.USER})
+    public ResponseEntity<MyPageResponse> me(
             @PathVariable(name = "userId") Long userId
     ) {
-        MyPageResponse response = userUseCase.myPage(userId);
+        MyPageResponse response = userUseCase.me(userId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
     }
+
+    @PostMapping("/admin/only")
+    @Permission(UserRole.ADMIN) // ADMIN만 허용
+    public ResponseEntity<String> adminOnly(
+            @CurrentUser CurrentUserInfo currentUser
+    ) {
+        return ResponseEntity.ok("ok" + currentUser.userId());
+    }
+
 
     @DeleteMapping("/{userId}")
     public ResponseEntity<Void> deleteUser(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,4 +41,4 @@ security:
       - /api/v1/auth/**
     exclude-methods:
       - OPTIONS
-    access-token-cookie: ""
+    access-token-cookie: null

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,15 @@ spring:
     access-token-expiration: ${ACCESS-TOKEN-EXPIRATION}
     refresh-token-expiration: ${REFRESH-TOKEN-EXPIRATION}
 
+security:
+  jwt-filter:
+    exclude-paths:
+      - /actuator/**
+      - /docs/**
+      - /v3/api-docs/**
+      - /swagger-ui/**
+      - /error
+      - /api/v1/auth/**
+    exclude-methods:
+      - OPTIONS
+    access-token-cookie: ""

--- a/src/test/java/com/community/soap/user/http/user-service-request.http
+++ b/src/test/java/com/community/soap/user/http/user-service-request.http
@@ -52,3 +52,12 @@ X-User-Id: {{userId}}
   "refreshToken": "{{refreshToken}}"
 }
 
+###
+GET http://localhost:8080/api/v1/users/{{userId}}
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+###
+POST http://localhost:8080/api/v1/users/admin/only
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [ ] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- OncePerRequestFilter 로 요청 API 접근 권한 검사 -> 화이트리스트 구현
- 회원의 권한 확인을 위한 Aspect 구현
- 접속 중인 회원의 정보를 JWT 를 통해 확인할 수 있도록 Resolver 구현

## 🔍 관련 이슈
- Closes #16

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - JWT 기반 인증 필터 도입으로 요청 인증 지원 및 예외 일원화
  - 메서드 단위 권한 어노테이션으로 역할 기반 접근 제어 추가
  - 컨트롤러에 현재 사용자 정보 자동 주입 지원
  - 관리자 전용 엔드포인트 추가(/api/v1/users/admin/only)

- 변경 사항
  - 마이페이지 조회 엔드포인트 명칭을 me로 변경
  - 인증 제외 경로/메서드 설정 추가 (application.yml)

- 테스트/문서
  - 사용자 조회 및 관리자 호출용 HTTP 예제 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->