### PR TITLE
User: 로그아웃 개선

### DIFF
--- a/src/main/java/com/community/soap/user/application/UserUseCase.java
+++ b/src/main/java/com/community/soap/user/application/UserUseCase.java
@@ -16,7 +16,7 @@ public interface UserUseCase {
 
     void deleteUser(Long userId);
 
-    void logout(String authorization, String s, Long userId);
+    void logout(String authorizationHeader, String refreshToken, Long userIdFromCtx);
 
     SignInResponse refresh(String refreshToken);
 }

--- a/src/main/java/com/community/soap/user/application/request/LogoutRequest.java
+++ b/src/main/java/com/community/soap/user/application/request/LogoutRequest.java
@@ -1,6 +1,10 @@
 package com.community.soap.user.application.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record LogoutRequest(
+
+        @NotBlank(message = "리프레시 토큰: 리프레시 토큰은 필수입니다.")
         String refreshToken
 ) {
 

--- a/src/main/java/com/community/soap/user/presentation/AuthController.java
+++ b/src/main/java/com/community/soap/user/presentation/AuthController.java
@@ -1,5 +1,7 @@
 package com.community.soap.user.presentation;
 
+import com.community.soap.common.resolver.CurrentUser;
+import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.user.application.UserUseCase;
 import com.community.soap.user.application.request.LogoutRequest;
 import com.community.soap.user.application.request.RefreshRequest;
@@ -49,10 +51,10 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
             @RequestHeader(name = "Authorization", required = false) String authorization,
-            @RequestHeader(name = "X-User-Id") Long userId, // 프로젝트 방식에 맞게 (예: 게이트웨이에서 주입)
-            @RequestBody LogoutRequest request
+            @RequestBody @Valid LogoutRequest request,
+            @CurrentUser CurrentUserInfo info
     ) {
-        userUseCase.logout(authorization, request.refreshToken(), userId);
+        userUseCase.logout(authorization, request.refreshToken(), info.userId());
         return ResponseEntity.ok(LogoutResponse.ok());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,9 @@ security:
       - /v3/api-docs/**
       - /swagger-ui/**
       - /error
-      - /api/v1/auth/**
+      - /api/v1/auth/signup
+      - /api/v1/auth/sign-in
+      - /api/v1/auth/token/refresh
     exclude-methods:
       - OPTIONS
     access-token-cookie: null

--- a/src/test/java/com/community/soap/user/http/user-service-request.http
+++ b/src/test/java/com/community/soap/user/http/user-service-request.http
@@ -46,7 +46,6 @@ Content-Type: application/json
 POST http://localhost:8080/api/v1/auth/logout
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
-X-User-Id: {{userId}}
 
 {
   "refreshToken": "{{refreshToken}}"


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- 로그아웃 시 RT 소유자를 확인합니다.
- exclude path에서 logout 경로를 제외하여 Filter를 거쳐서 Bearer AT에서 userId를 파싱하여 attribute로 저장된 값은 @CurrentUserInfo에서 getAttribute로 userId를 가져올 수 있습니다. 따라서 AT, RT의 userId 비교를 통해 소유자, 무결성, 진정성 확인합니다. 그래서 exclute path에 포함되지 않은 엔드포인트들은 반드시 Filter를 거치게 된다는 점을 기억합니다.

## 🔍 관련 이슈
- Closes #21

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 로그아웃 시 토큰 소유자 검증과 토큰 바인딩 검증을 강화해 보안과 안정성을 향상했습니다.
  * 리프레시 토큰 불일치/변조 상황을 방지하고, 중복 요청에도 안전하도록 처리했습니다.
* **Refactor**
  * 로그아웃 요청에서 사용자 식별을 헤더값 대신 컨텍스트 기반으로 일원화했습니다.
  * 파라미터 명을 가독성 있게 정리했습니다.
* **Chores**
  * JWT 필터 제외 경로를 최소화하여 /auth 내 일부 엔드포인트에 인증을 적용했습니다.
* **Tests**
  * 테스트 요청에서 X-User-Id 헤더를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->