### PR TITLE
User: 마이페이지 조회와 로그아웃 고도화 구현

### DIFF
--- a/src/main/java/com/community/soap/user/application/UserService.java
+++ b/src/main/java/com/community/soap/user/application/UserService.java
@@ -124,9 +124,10 @@ public class UserService implements UserUseCase {
         // AT 블랙리스트 (소유자 일치시에만)
         blacklistAccessIfOwner(authorizationHeader, userIdFromCtx);
 
-        // RT 폐기 (단일 rJti)
-        revokeRefreshByJti(userIdFromCtx, rJti, TokenHash.sha256(refreshToken),
-                jwtProvider.refreshTokenTtlOf(refreshToken).toMillis());
+        // RT 폐기 (단일 rJti) - 해시/TTL 1회 계산
+        String refreshHash = TokenHash.sha256(refreshToken);
+        long refreshTtlMs = jwtProvider.refreshTokenTtlOf(refreshToken).toMillis();
+        revokeRefreshByJti(userIdFromCtx, rJti, refreshHash, refreshTtlMs);
     }
 
     @Transactional

--- a/src/main/java/com/community/soap/user/application/UserService.java
+++ b/src/main/java/com/community/soap/user/application/UserService.java
@@ -3,6 +3,7 @@ package com.community.soap.user.application;
 import com.community.soap.common.jwt.JwtErrorCode;
 import com.community.soap.common.jwt.JwtProvider;
 import com.community.soap.common.jwt.TokenException;
+import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.common.snowflake.Snowflake;
 import com.community.soap.common.util.TokenHash;
 import com.community.soap.user.application.exception.UserErrorCode;
@@ -15,6 +16,8 @@ import com.community.soap.user.application.response.SignUpResponse;
 import com.community.soap.user.domain.entity.User;
 import com.community.soap.user.domain.repository.TokenRepository;
 import com.community.soap.user.domain.repository.UserRepository;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -97,10 +100,9 @@ public class UserService implements UserUseCase {
         return SignInResponse.of(user, accessToken, accessTtlMs, refreshToken, refreshTtlMs);
     }
 
+
     /**
-     * 로그아웃:
-     * 1) Access jti 블랙리스트(즉시 효과)
-     * 2) Refresh jti 블랙리스트 + 저장소에서 제거 + 유저 인덱스 제거
+     * 로그아웃: 단일 세션(rJti)만 정확히 폐기. - AT는 소유자 일치 시 블랙리스트 - RT는 rJti 단위로 검증/블랙리스트/삭제/인덱스 제거
      */
     @Transactional
     @Override
@@ -109,52 +111,22 @@ public class UserService implements UserUseCase {
             throw new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN);
         }
 
-        // 0) RT 소유자 확인
         Long userIdFromRt = jwtProvider.getUserIdFromRefresh(refreshToken);
         if (!userIdFromRt.equals(userIdFromCtx)) {
             throw new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN);
         }
 
-        // (선택) RT Claim 확인: rJti가 정말 이 유저의 세션인지
         String rJti = jwtProvider.getRefreshJti(refreshToken);
         if (!tokenRepository.getUserRefreshJtis(userIdFromCtx).contains(rJti)) {
             throw new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN);
         }
 
-        // 1) Access 무효화 (있을 때만, 그리고 소유자 일치 시)
-        if (authorizationHeader != null && !authorizationHeader.isBlank()) {
-            try {
-                Long userIdFromAt = jwtProvider.getUserId(authorizationHeader);
-                if (userIdFromAt.equals(userIdFromCtx)) {
-                    String aJti = jwtProvider.getJti(authorizationHeader);
-                    long aTtlMs = jwtProvider.accessTokenTtlOf(authorizationHeader).toMillis();
-                    if (aTtlMs > 0) {
-                        tokenRepository.blacklistAccessJti(aJti, aTtlMs); // setIfAbsent로 TTL 연장 방지
-                    }
-                } // else: AT 소유자 불일치 → AT 블랙리스트 생략(또는 400/403 반환 정책 가능)
-            } catch (TokenException e) {
-                // AT 만료/형식오류 등은 로그만 남기고 넘어가도 됨(로그아웃의 본질은 RT 폐기)
-                // log.debug("ignore invalid access on logout", e);
-            }
-        }
+        // AT 블랙리스트 (소유자 일치시에만)
+        blacklistAccessIfOwner(authorizationHeader, userIdFromCtx);
 
-        // 2) RT 본인 검증(해시) + 블랙리스트 + 저장소 정리
-        String inputHash = TokenHash.sha256(refreshToken);
-        String storedHash = tokenRepository.getRefreshTokenHashByJti(rJti)
-                .orElse(null);
-
-        // 멱등성: 이미 지워졌다면 "이미 처리됨"으로 넘어가도 운영이 편하다
-        if (storedHash != null && !storedHash.equals(inputHash)) {
-            throw new TokenException(JwtErrorCode.TAMPERED_TOKEN);
-        }
-
-        long rTtlMs = jwtProvider.refreshTokenTtlOf(refreshToken).toMillis();
-        if (rTtlMs > 0) {
-            tokenRepository.blacklistRefreshJti(rJti, rTtlMs);
-        }
-
-        tokenRepository.deleteRefreshTokenByJti(rJti);           // RT 해시 삭제
-        tokenRepository.removeUserRefreshIndex(userIdFromCtx, rJti); // 세션 인덱스 제거
+        // RT 폐기 (단일 rJti)
+        revokeRefreshByJti(userIdFromCtx, rJti, TokenHash.sha256(refreshToken),
+                jwtProvider.refreshTokenTtlOf(refreshToken).toMillis());
     }
 
     @Transactional
@@ -207,16 +179,98 @@ public class UserService implements UserUseCase {
 
     @Transactional(readOnly = true)
     @Override
-    public MyPageResponse me(Long userId) {
-        User byUserId = findUserById(userId);
+    public MyPageResponse me(CurrentUserInfo info) {
+        User byUserId = findUserById(info.userId());
 
         return MyPageResponse.from(byUserId);
     }
 
     @Transactional
     @Override
-    public void deleteUser(Long userId) {
-        User byUserId = findUserById(userId);
-        byUserId.delete(userId);
+    public void deleteMe(String authorizationHeader, Long userIdFromCtx) {
+        // 1) 사용자 존재 확인
+        User user = findUserById(userIdFromCtx);
+
+        // 2) AT 블랙리스트 + RT 전부 폐기
+        blacklistAccessIfOwner(authorizationHeader, user.getUserId());
+        revokeAllRefreshOfUser(user.getUserId());
+
+        // 3) 유저 soft-delete
+        user.softDelete(user.getUserId());
+    }
+
+    /**
+     * 관리자 강제 탈퇴: 세션 정리 + soft-delete (컨트롤러/어드바이저에서 관리자 권한 체크)
+     */
+    @Transactional
+    @Override
+    public void deleteUserAsAdmin(Long targetUserId) {
+        User target = findUserById(targetUserId);
+
+        revokeAllRefreshOfUser(target.getUserId()); // AT 모를 수 있으니 RT만 전부 폐기
+        target.softDelete(target.getUserId());
+    }
+
+    /**
+     * AT가 주어졌고 소유자가 targetUserId와 일치하면 블랙리스트 등록
+     */
+    private void blacklistAccessIfOwner(String authorizationHeader, Long targetUserId) {
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            return;
+        }
+
+        try {
+            Long uidFromAt = jwtProvider.getUserId(authorizationHeader);
+            if (!uidFromAt.equals(targetUserId)) {
+                return;
+            }
+
+            String aJti = jwtProvider.getJti(authorizationHeader);
+            long aTtlMs = jwtProvider.accessTokenTtlOf(authorizationHeader).toMillis();
+            if (aTtlMs > 0) {
+                tokenRepository.blacklistAccessJti(aJti, aTtlMs); // setIfAbsent로 TTL 연장 방지
+            }
+        } catch (TokenException ignore) {
+            // AT 만료/형식 오류 등은 무시 (주 목적은 RT 폐기)
+        }
+    }
+
+    /**
+     * 단일 rJti에 대한 RT 폐기(검증·블랙리스트·삭제·인덱스제거)
+     */
+    private void revokeRefreshByJti(Long userId, String rJti, String inputRefreshHash,
+            long refreshTtlMs) {
+        // 1) 멱등/위변조 방지: 저장된 해시와 비교 (저장소에 없으면 이미 처리된 것으로 간주)
+        String storedHash = tokenRepository.getRefreshTokenHashByJti(rJti).orElse(null);
+        if (storedHash != null && !storedHash.equals(inputRefreshHash)) {
+            throw new TokenException(JwtErrorCode.TAMPERED_TOKEN);
+        }
+
+        // 2) 블랙리스트 (TTL 있을 때만)
+        if (refreshTtlMs > 0) {
+            tokenRepository.blacklistRefreshJti(rJti, refreshTtlMs);
+        }
+
+        // 3) 저장소 삭제 + 인덱스 제거
+        tokenRepository.deleteRefreshTokenByJti(rJti);
+        tokenRepository.removeUserRefreshIndex(userId, rJti);
+    }
+
+    /**
+     * 해당 유저의 모든 RT 세션을 일괄 폐기(블랙리스트 가능 시 포함) -> revokeAllRefreshOfUser를 배치 API로 치환
+     */
+    private void revokeAllRefreshOfUser(Long targetUserId) {
+        // 1) rJti 전부 꺼내면서 인덱스 비우기 (원자)
+        Set<String> rJtis = tokenRepository.popAllUserRefreshJtis(targetUserId);
+        if (rJtis.isEmpty()) {
+            return;
+        }
+
+        // 2) TTL 일괄 조회(파이프라인)
+        Map<String, Long> jtiToTtl = tokenRepository.mgetRemainingRefreshTtlsMs(rJtis);
+        // 3) 블랙리스트 일괄 등록(파이프라인) – TTL 있는 것만
+        tokenRepository.mblacklistRefreshJtis(jtiToTtl);
+        // 4) RT 해시 일괄 삭제(파이프라인)
+        tokenRepository.mdeleteRefreshTokensByJtis(rJtis);
     }
 }

--- a/src/main/java/com/community/soap/user/application/UserService.java
+++ b/src/main/java/com/community/soap/user/application/UserService.java
@@ -50,12 +50,12 @@ public class UserService implements UserUseCase {
         }
     }
 
-    private void checkPassword(String rowPassword, String encryptedPassword) {
-        if (rowPassword == null || rowPassword.isEmpty()) {
+    private void checkPassword(String rawPassword, String encryptedPassword) {
+        if (rawPassword == null || rawPassword.isEmpty()) {
             throw new UserException(UserErrorCode.PASSWORD_NULL);
         }
 
-        if (!passwordEncoder.matches(rowPassword, encryptedPassword)) {
+        if (!passwordEncoder.matches(rawPassword, encryptedPassword)) {
             throw new UserException(UserErrorCode.PASSWORD_INCORRECT);
         }
     }

--- a/src/main/java/com/community/soap/user/application/UserService.java
+++ b/src/main/java/com/community/soap/user/application/UserService.java
@@ -117,7 +117,7 @@ public class UserService implements UserUseCase {
         }
 
         String rJti = jwtProvider.getRefreshJti(refreshToken);
-        if (!tokenRepository.getUserRefreshJtis(userIdFromCtx).contains(rJti)) {
+        if (!tokenRepository.hasUserRefreshJti(userIdFromCtx, rJti)) {
             throw new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN);
         }
 

--- a/src/main/java/com/community/soap/user/application/UserUseCase.java
+++ b/src/main/java/com/community/soap/user/application/UserUseCase.java
@@ -1,5 +1,6 @@
 package com.community.soap.user.application;
 
+import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.user.application.request.SignInRequest;
 import com.community.soap.user.application.request.SignUpRequest;
 import com.community.soap.user.application.response.MyPageResponse;
@@ -12,9 +13,11 @@ public interface UserUseCase {
 
     SignInResponse signIn(SignInRequest request);
 
-    MyPageResponse me(Long userId);
+    MyPageResponse me(CurrentUserInfo info);
 
-    void deleteUser(Long userId);
+    void deleteUserAsAdmin(Long targetUserId);
+
+    void deleteMe(String authorizationHeader, Long userIdFromCtx);
 
     void logout(String authorizationHeader, String refreshToken, Long userIdFromCtx);
 

--- a/src/main/java/com/community/soap/user/application/exception/UserErrorCode.java
+++ b/src/main/java/com/community/soap/user/application/exception/UserErrorCode.java
@@ -15,7 +15,6 @@ public enum UserErrorCode implements ErrorCode {
     PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호: 비밀번호가 틀립니다."),
     PASSWORD_NULL(HttpStatus.BAD_REQUEST, "비밀번호: 비밀번호 입력은 필수입니다."),
 
-
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이메일: 이미 사용 중인 이메일입니다."),
     EMAIL_INVALID(HttpStatus.BAD_REQUEST, "이메일: 이메일 형식이 올바르지 않습니다."),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "이메일: 이메일을 찾을 수 없습니다.");

--- a/src/main/java/com/community/soap/user/domain/entity/User.java
+++ b/src/main/java/com/community/soap/user/domain/entity/User.java
@@ -66,7 +66,7 @@ public class User {
         update(userId);
     }
 
-    public void delete(Long userId) {
+    public void softDelete(Long userId) {
         this.isDeleted = Boolean.TRUE;
         update(userId);
     }

--- a/src/main/java/com/community/soap/user/domain/repository/TokenRepository.java
+++ b/src/main/java/com/community/soap/user/domain/repository/TokenRepository.java
@@ -1,5 +1,6 @@
 package com.community.soap.user.domain.repository;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,4 +22,12 @@ public interface TokenRepository {
     void blacklistRefreshJti(String jti, long ttlMillis); // 선택
     boolean isAccessJtiBlacklisted(String jti);
     boolean isRefreshJtiBlacklisted(String jti);
+
+    Optional<Long> getRemainingRefreshTtlMs(String rJti);
+
+    // TokenRepository (선택)
+    Set<String> popAllUserRefreshJtis(Long userId); // 인덱스에서 rJti 모두 꺼내면서 비움
+    Map<String, Long> mgetRemainingRefreshTtlsMs(Set<String> rJtis); // 여러 jti TTL 일괄 조회
+    void mdeleteRefreshTokensByJtis(Set<String> rJtis); // 여러 RT 해시 일괄 삭제
+    void mblacklistRefreshJtis(Map<String, Long> jtiToTtlMs); // 여러 rJti 블랙리스트
 }

--- a/src/main/java/com/community/soap/user/domain/repository/TokenRepository.java
+++ b/src/main/java/com/community/soap/user/domain/repository/TokenRepository.java
@@ -25,6 +25,9 @@ public interface TokenRepository {
 
     Optional<Long> getRemainingRefreshTtlMs(String rJti);
 
+    /** 유저의 인덱스 SET에 해당 rJti가 포함되는지 빠르게 확인 */
+    boolean hasUserRefreshJti(Long userId, String jti);
+
     // TokenRepository (선택)
     Set<String> popAllUserRefreshJtis(Long userId); // 인덱스에서 rJti 모두 꺼내면서 비움
     Map<String, Long> mgetRemainingRefreshTtlsMs(Set<String> rJtis); // 여러 jti TTL 일괄 조회

--- a/src/main/java/com/community/soap/user/persistence/JwtRepository.java
+++ b/src/main/java/com/community/soap/user/persistence/JwtRepository.java
@@ -126,6 +126,12 @@ public class JwtRepository implements TokenRepository {
         return Optional.of(ttlMs);
     }
 
+    @Override
+    public boolean hasUserRefreshJti(Long userId, String jti) {
+        // Redis SISMEMBER 사용
+        return Boolean.TRUE.equals(redis.opsForSet().isMember(kUserRt(userId), jti));
+    }
+
     /**
      * 유저 인덱스(SET)에서 모든 rJti를 원자적으로 가져오고 키를 비운다. Lua: SMEMBERS key; DEL key; return members;
      */

--- a/src/main/java/com/community/soap/user/persistence/JwtRepository.java
+++ b/src/main/java/com/community/soap/user/persistence/JwtRepository.java
@@ -1,12 +1,25 @@
 package com.community.soap.user.persistence;
 
 import com.community.soap.user.domain.repository.TokenRepository;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.RedisStringCommands.SetOption;
+import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.stereotype.Repository;
 
 
@@ -36,11 +49,11 @@ public class JwtRepository implements TokenRepository {
 
     @Override
     public void saveRefreshToken(String jti, Long userId, String refreshTokenHash, long ttlMillis) {
-        // 토큰 본문(해시) 저장
+        // 토큰 본문(해시) 저장 -> RT 해시 저장 + TTL 설정
         redis.opsForValue().set(kRt(jti), refreshTokenHash, Duration.ofMillis(ttlMillis));
         // 유저-세션 인덱스(SET)에 jti 추가
         redis.opsForSet().add(kUserRt(userId), jti);
-        // 인덱스 키는 굳이 TTL 줄 필요는 없음(원하면 정책적으로 부여)
+        // 인덱스 키는 굳이 TTL 줄 필요는 없음(원하면 정책적으로 부여. 세션 수명과 무관, 정합성 측면에서 권장 X)
     }
 
     @Override
@@ -74,9 +87,9 @@ public class JwtRepository implements TokenRepository {
     public void deleteAllRefreshTokensOfUser(Long userId) {
         Set<String> jtis = getUserRefreshJtis(userId);
         if (jtis != null && !jtis.isEmpty()) {
-            // RT 본문 삭제
+            // RT 본문 일괄 삭제
             redis.delete(jtis.stream().map(JwtRepository::kRt).toList());
-            // 인덱스 비움
+            // 유저 인덱스 삭제
             redis.delete(kUserRt(userId));
         }
     }
@@ -100,5 +113,126 @@ public class JwtRepository implements TokenRepository {
     @Override
     public boolean isRefreshJtiBlacklisted(String jti) {
         return Boolean.TRUE.equals(redis.hasKey(kBlR(jti)));
+    }
+
+    @Override
+    public Optional<Long> getRemainingRefreshTtlMs(String rJti) {
+        // TTL(ms) 조회. Redis는 -2(키 없음), -1(TTL 없음) 반환 가능
+        Long ttlMs = redis.getExpire(kRt(rJti), TimeUnit.MILLISECONDS);
+        if (ttlMs == null || ttlMs <= 0) {
+            // 키가 없거나, TTL이 없거나(영속), 이미 만료 직전 등 → 블랙리스트 생략
+            return Optional.empty();
+        }
+        return Optional.of(ttlMs);
+    }
+
+    /**
+     * 유저 인덱스(SET)에서 모든 rJti를 원자적으로 가져오고 키를 비운다. Lua: SMEMBERS key; DEL key; return members;
+     */
+    @Override
+    public Set<String> popAllUserRefreshJtis(Long userId) {
+        String idxKey = kUserRt(userId);
+        byte[] key = redis.getStringSerializer().serialize(idxKey);
+
+        // Lua 스크립트 (원자적 실행)
+        String script = "local k=KEYS[1]; local m=redis.call('SMEMBERS',k); redis.call('DEL',k); return m;";
+        @SuppressWarnings("unchecked")
+        List<byte[]> result = (List<byte[]>) redis.execute((RedisCallback<Object>) connection ->
+                connection.scriptingCommands().eval(
+                        script.getBytes(StandardCharsets.UTF_8),
+                        ReturnType.MULTI, 1, key
+                )
+        );
+
+        if (result == null || result.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        return result.stream()
+                .map(b -> redis.getStringSerializer().deserialize(b))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * 여러 rJti의 남은 TTL(ms)을 파이프라인으로 일괄 조회(PTTL). TTL <= 0(-2, -1 포함)은 제외.
+     */
+    @Override
+    public Map<String, Long> mgetRemainingRefreshTtlsMs(Set<String> rJtis) {
+        if (rJtis == null || rJtis.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        final var ser = redis.getStringSerializer();
+        final List<String> order = new ArrayList<>(rJtis);
+
+        @SuppressWarnings("unchecked")
+        List<Object> raw = redis.executePipelined((RedisCallback<Object>) connection -> {
+            for (String rJti : order) {
+                byte[] key = ser.serialize(kRt(rJti));
+                connection.keyCommands().pTtl(key);
+            }
+            return null;
+        });
+
+        Map<String, Long> out = new LinkedHashMap<>(order.size());
+        for (int i = 0; i < order.size(); i++) {
+            Object val = raw.get(i);
+            Long ttl = (val instanceof Long) ? (Long) val : null;
+            if (ttl != null && ttl > 0) {
+                out.put(order.get(i), ttl);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * 여러 RT 해시 키를 파이프라인으로 일괄 삭제.
+     */
+    @Override
+    public void mdeleteRefreshTokensByJtis(Set<String> rJtis) {
+        if (rJtis == null || rJtis.isEmpty()) {
+            return;
+        }
+
+        final var ser = redis.getStringSerializer();
+        redis.executePipelined((RedisCallback<Object>) connection -> {
+            for (String rJti : rJtis) {
+                connection.keyCommands().del(ser.serialize(kRt(rJti)));
+            }
+            return null;
+        });
+    }
+
+    /**
+     * 여러 rJti를 블랙리스트에 일괄 등록(SET NX PX ttl) – 파이프라인 적용. 이미 존재하는 키는 TTL 연장하지 않음.
+     */
+    @Override
+    public void mblacklistRefreshJtis(Map<String, Long> jtiToTtlMs) {
+        if (jtiToTtlMs == null || jtiToTtlMs.isEmpty()) {
+            return;
+        }
+
+        final var ser = redis.getStringSerializer();
+        byte[] value = ser.serialize("1");
+
+        redis.executePipelined((RedisCallback<Object>) connection -> {
+            for (Map.Entry<String, Long> e : jtiToTtlMs.entrySet()) {
+                String jti = e.getKey();
+                long ttl = e.getValue() == null ? 0 : e.getValue();
+                if (ttl <= 0) {
+                    continue;
+                }
+
+                byte[] key = ser.serialize(kBlR(jti));
+                connection.stringCommands().set(
+                        key,
+                        value,
+                        Expiration.milliseconds(ttl),
+                        SetOption.ifAbsent()
+                );
+            }
+            return null;
+        });
     }
 }

--- a/src/main/java/com/community/soap/user/persistence/JwtRepository.java
+++ b/src/main/java/com/community/soap/user/persistence/JwtRepository.java
@@ -86,12 +86,16 @@ public class JwtRepository implements TokenRepository {
     @Override
     public void deleteAllRefreshTokensOfUser(Long userId) {
         Set<String> jtis = getUserRefreshJtis(userId);
-        if (jtis != null && !jtis.isEmpty()) {
-            // RT 본문 일괄 삭제
-            redis.delete(jtis.stream().map(JwtRepository::kRt).toList());
-            // 유저 인덱스 삭제
-            redis.delete(kUserRt(userId));
+
+        if (jtis.isEmpty()) {
+            return;
         }
+
+        // RT 본문 일괄 삭제
+        redis.delete(jtis.stream().map(JwtRepository::kRt).toList());
+        // 유저 인덱스 삭제
+        redis.delete(kUserRt(userId));
+
     }
 
     @Override

--- a/src/main/java/com/community/soap/user/presentation/UserController.java
+++ b/src/main/java/com/community/soap/user/presentation/UserController.java
@@ -11,8 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,32 +22,25 @@ public class UserController {
 
     private final UserUseCase userUseCase;
 
-    @GetMapping("/{userId}")
+    @GetMapping("/me")
     @Permission(value = {UserRole.ADMIN, UserRole.MANAGER, UserRole.USER})
     public ResponseEntity<MyPageResponse> me(
-            @PathVariable(name = "userId") Long userId
+            @CurrentUser CurrentUserInfo info
     ) {
-        MyPageResponse response = userUseCase.me(userId);
+        MyPageResponse response = userUseCase.me(info);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
     }
 
-    @PostMapping("/admin/only")
-    @Permission(UserRole.ADMIN) // ADMIN만 허용
-    public ResponseEntity<String> adminOnly(
-            @CurrentUser CurrentUserInfo currentUser
+    @Permission(value = {UserRole.ADMIN, UserRole.MANAGER, UserRole.USER})
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMe(
+            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @CurrentUser CurrentUserInfo info
     ) {
-        return ResponseEntity.ok("ok" + currentUser.userId());
-    }
-
-
-    @DeleteMapping("/{userId}")
-    public ResponseEntity<Void> deleteUser(
-            @PathVariable(name = "userId") Long userId
-    ) {
-        userUseCase.deleteUser(userId);
+        userUseCase.deleteMe(authorization, info.userId());
 
         return ResponseEntity
                 .noContent()

--- a/src/test/java/com/community/soap/user/http/user-service-request.http
+++ b/src/test/java/com/community/soap/user/http/user-service-request.http
@@ -51,12 +51,13 @@ Authorization: Bearer {{accessToken}}
   "refreshToken": "{{refreshToken}}"
 }
 
-###
-GET http://localhost:8080/api/v1/users/{{userId}}
+### (회원)마이페이지
+GET http://localhost:8080/api/v1/users/me
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
-###
-POST http://localhost:8080/api/v1/users/admin/only
+
+### (회원)회원탈퇴
+DELETE http://localhost:8080/api/v1/users/me
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- TokenRepository / JwtRepository: 세션 일괄 폐기(batch) API 추가 및 안전한 블랙리스트 처리
- UserService: 본인 탈퇴/세션 폐기 로직 정리 및 보안/성능 개선
- 마이페이지와 회원탈퇴 엔드포인트 수정 및 인증 방식 변경

## 🔍 관련 이슈
- Closes #23

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 마이페이지 조회: GET /api/v1/users/me (현재 사용자 기준)
  - 회원 본인 탈퇴: DELETE /api/v1/users/me (요청자 토큰 검증 후 세션/토큰 일괄 종료)
  - 관리자 강제 삭제: 사용자 모든 세션 일괄 종료 후 계정 삭제 기능 추가
- Changes
  - 사용자 삭제 및 로그아웃 토큰 처리: 개별 토큰(JTI) 단위 폐기 및 대량 폐기 지원으로 효율성 향상
- Documentation
  - HTTP 예제 갱신: 마이페이지 조회 및 회원탈퇴 시나리오 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->