### PR TITLE
Architecture: 의존 관계 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ user.gradle
 .gradle/
 target/
 build/
-out/
+.out/
 
 *.DS_Store
 *.class

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ user.gradle
 .gradle/
 target/
 build/
-.out/
+/out/
 
 *.DS_Store
 *.class

--- a/src/main/java/com/community/soap/user/application/policy/EmailVerificationPolicy.java
+++ b/src/main/java/com/community/soap/user/application/policy/EmailVerificationPolicy.java
@@ -1,0 +1,16 @@
+package com.community.soap.user.application.policy;
+
+import java.time.Duration;
+
+public interface EmailVerificationPolicy {
+
+    Duration codeTtl();
+
+    Duration cooltime();
+
+    Duration blockTtl();
+
+    long maxAttempts();
+
+    Duration verifiedTtl();
+}

--- a/src/main/java/com/community/soap/user/application/port/in/UserUseCase.java
+++ b/src/main/java/com/community/soap/user/application/port/in/UserUseCase.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.application;
+package com.community.soap.user.application.port.in;
 
 import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.user.application.request.EmailVerificationCodeRequest;
@@ -9,7 +9,6 @@ import com.community.soap.user.application.response.EmailVerificationCodeRespons
 import com.community.soap.user.application.response.MyPageResponse;
 import com.community.soap.user.application.response.SignInResponse;
 import com.community.soap.user.application.response.SignUpResponse;
-import jakarta.validation.Valid;
 
 public interface UserUseCase {
 

--- a/src/main/java/com/community/soap/user/application/port/in/UserUseCase.java
+++ b/src/main/java/com/community/soap/user/application/port/in/UserUseCase.java
@@ -1,6 +1,5 @@
 package com.community.soap.user.application.port.in;
 
-import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.user.application.request.EmailVerificationCodeRequest;
 import com.community.soap.user.application.request.EmailVerifyCodeRequest;
 import com.community.soap.user.application.request.SignInRequest;
@@ -16,7 +15,7 @@ public interface UserUseCase {
 
     SignInResponse signIn(SignInRequest request);
 
-    MyPageResponse me(CurrentUserInfo info);
+    MyPageResponse me(Long userId);
 
     void deleteUserAsAdmin(Long targetUserId);
 

--- a/src/main/java/com/community/soap/user/application/port/out/EmailSenderPort.java
+++ b/src/main/java/com/community/soap/user/application/port/out/EmailSenderPort.java
@@ -1,0 +1,8 @@
+package com.community.soap.user.application.port.out;
+
+
+import java.time.Duration;
+
+public interface EmailSenderPort {
+    void sendVerificationCode(String email, String code, Duration ttl, String brand);
+}

--- a/src/main/java/com/community/soap/user/application/port/out/EmailVerificationRepositoryPort.java
+++ b/src/main/java/com/community/soap/user/application/port/out/EmailVerificationRepositoryPort.java
@@ -1,9 +1,9 @@
-package com.community.soap.user.domain.repository;
+package com.community.soap.user.application.port.out;
 
 import java.time.Duration;
 import java.util.Optional;
 
-public interface EmailVerificationRepository {
+public interface EmailVerificationRepositoryPort {
     void saveCodeHash(String email, String codeHash, Duration ttl);
     Optional<String> getCodeHash(String email);
     void deleteCode(String email);

--- a/src/main/java/com/community/soap/user/application/port/out/TokenRepositoryPort.java
+++ b/src/main/java/com/community/soap/user/application/port/out/TokenRepositoryPort.java
@@ -1,10 +1,10 @@
-package com.community.soap.user.domain.repository;
+package com.community.soap.user.application.port.out;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-public interface TokenRepository {
+public interface TokenRepositoryPort {
 
     // Refresh Token 저장/조회/삭제 (jti 기준)
     void saveRefreshToken(String jti, Long userId, String refreshTokenHash, long ttlMillis);

--- a/src/main/java/com/community/soap/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/community/soap/user/application/port/out/UserRepositoryPort.java
@@ -1,9 +1,9 @@
-package com.community.soap.user.domain.repository;
+package com.community.soap.user.application.port.out;
 
 import com.community.soap.user.domain.entity.User;
 import java.util.Optional;
 
-public interface UserRepository {
+public interface UserRepositoryPort {
 
     Optional<User> findByEmail(String email);
 

--- a/src/main/java/com/community/soap/user/application/service/UserService.java
+++ b/src/main/java/com/community/soap/user/application/service/UserService.java
@@ -3,7 +3,6 @@ package com.community.soap.user.application.service;
 import com.community.soap.common.jwt.JwtErrorCode;
 import com.community.soap.common.jwt.JwtProvider;
 import com.community.soap.common.jwt.TokenException;
-import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.common.snowflake.Snowflake;
 import com.community.soap.common.util.TokenHash;
 import com.community.soap.user.application.policy.EmailVerificationPolicy;
@@ -192,8 +191,8 @@ public class UserService implements UserUseCase {
 
     @Transactional(readOnly = true)
     @Override
-    public MyPageResponse me(CurrentUserInfo info) {
-        User byUserId = findUserById(info.userId());
+    public MyPageResponse me(Long userId) {
+        User byUserId = findUserById(userId);
 
         return MyPageResponse.from(byUserId);
     }

--- a/src/main/java/com/community/soap/user/application/service/UserService.java
+++ b/src/main/java/com/community/soap/user/application/service/UserService.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.application;
+package com.community.soap.user.application.service;
 
 import com.community.soap.common.jwt.JwtErrorCode;
 import com.community.soap.common.jwt.JwtProvider;
@@ -6,8 +6,12 @@ import com.community.soap.common.jwt.TokenException;
 import com.community.soap.common.resolver.CurrentUserInfo;
 import com.community.soap.common.snowflake.Snowflake;
 import com.community.soap.common.util.TokenHash;
-import com.community.soap.user.application.exception.UserErrorCode;
-import com.community.soap.user.application.exception.UserException;
+import com.community.soap.user.application.policy.EmailVerificationPolicy;
+import com.community.soap.user.application.port.in.UserUseCase;
+import com.community.soap.user.application.port.out.EmailSenderPort;
+import com.community.soap.user.application.port.out.EmailVerificationRepositoryPort;
+import com.community.soap.user.application.port.out.TokenRepositoryPort;
+import com.community.soap.user.application.port.out.UserRepositoryPort;
 import com.community.soap.user.application.request.EmailVerificationCodeRequest;
 import com.community.soap.user.application.request.EmailVerifyCodeRequest;
 import com.community.soap.user.application.request.SignInRequest;
@@ -17,11 +21,8 @@ import com.community.soap.user.application.response.MyPageResponse;
 import com.community.soap.user.application.response.SignInResponse;
 import com.community.soap.user.application.response.SignUpResponse;
 import com.community.soap.user.domain.entity.User;
-import com.community.soap.user.domain.repository.EmailVerificationRepository;
-import com.community.soap.user.domain.repository.TokenRepository;
-import com.community.soap.user.domain.repository.UserRepository;
-import com.community.soap.user.persistence.external.email.ThymeleafEmailSender;
-import com.community.soap.user.persistence.external.naver.EmailVerificationProperties;
+import com.community.soap.user.domain.exception.UserErrorCode;
+import com.community.soap.user.domain.exception.UserException;
 import java.security.SecureRandom;
 import java.util.Map;
 import java.util.Set;
@@ -34,29 +35,29 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class UserService implements UserUseCase {
 
-    private final UserRepository userRepository;
+    private final UserRepositoryPort userRepositoryPort;
     private final PasswordEncoder passwordEncoder;
     private final Snowflake snowflake;
 
     private final JwtProvider jwtProvider;
-    private final TokenRepository tokenRepository;
+    private final TokenRepositoryPort tokenRepositoryPort;
 
-    private final EmailVerificationRepository emailRepo;
-    private final EmailVerificationProperties emailProps;
-    private final ThymeleafEmailSender thymeleafEmailSender;
+    private final EmailVerificationRepositoryPort emailVerificationRepositoryPort;
+    private final EmailVerificationPolicy emailPolicy;
+    private final EmailSenderPort emailSenderPort;
 
     private User findUserByEmail(String email) {
-        return userRepository.findByEmail(email)
+        return userRepositoryPort.findByEmail(email)
                 .orElseThrow(() -> new UserException(UserErrorCode.EMAIL_NOT_FOUND));
     }
 
     private User findUserById(Long userId) {
-        return userRepository.findByUserId(userId)
+        return userRepositoryPort.findByUserId(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 
     private void checkEmailDuplication(String email) {
-        if (userRepository.existsByEmail(email)) {
+        if (userRepositoryPort.existsByEmail(email)) {
             throw new UserException(UserErrorCode.EMAIL_DUPLICATED);
         }
     }
@@ -83,7 +84,7 @@ public class UserService implements UserUseCase {
                 request.nickname()
         );
 
-        userRepository.save(register);
+        userRepositoryPort.save(register);
 
         return SignUpResponse.from(register);
     }
@@ -105,7 +106,7 @@ public class UserService implements UserUseCase {
 
         // 3) 리프레시 토큰 해시 저장 (+ 유저-세션 인덱스)
         String refreshHash = TokenHash.sha256(refreshToken);
-        tokenRepository.saveRefreshToken(rJti, user.getUserId(), refreshHash, refreshTtlMs);
+        tokenRepositoryPort.saveRefreshToken(rJti, user.getUserId(), refreshHash, refreshTtlMs);
 
         // 4) 응답 구성
         return SignInResponse.of(user, accessToken, accessTtlMs, refreshToken, refreshTtlMs);
@@ -128,7 +129,7 @@ public class UserService implements UserUseCase {
         }
 
         String rJti = jwtProvider.getRefreshJti(refreshToken);
-        if (!tokenRepository.hasUserRefreshJti(userIdFromCtx, rJti)) {
+        if (!tokenRepositoryPort.hasUserRefreshJti(userIdFromCtx, rJti)) {
             throw new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN);
         }
 
@@ -151,28 +152,28 @@ public class UserService implements UserUseCase {
         // 1) 유효성/블랙리스트/해시 비교
         String rJti = jwtProvider.getRefreshJti(refreshToken);
 
-        if (tokenRepository.isRefreshJtiBlacklisted(rJti)) {
+        if (tokenRepositoryPort.isRefreshJtiBlacklisted(rJti)) {
             throw new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN);
         }
 
         String inputHash = TokenHash.sha256(refreshToken);
-        String storedHash = tokenRepository.getRefreshTokenHashByJti(rJti)
+        String storedHash = tokenRepositoryPort.getRefreshTokenHashByJti(rJti)
                 .orElseThrow(() -> new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN));
         if (!storedHash.equals(inputHash)) {
             throw new TokenException(JwtErrorCode.TAMPERED_TOKEN);
         }
 
         Long userId = jwtProvider.getUserIdFromRefresh(refreshToken);
-        User user = userRepository.findByUserId(userId)
+        User user = userRepositoryPort.findByUserId(userId)
                 .orElseThrow(() -> new TokenException(JwtErrorCode.INVALID_BEARER_TOKEN));
 
         // 2) 이전 rJti 폐기(블랙리스트 + 삭제 + 인덱스 제거)
         long oldRttl = jwtProvider.refreshTokenTtlOf(refreshToken).toMillis();
         if (oldRttl > 0) {
-            tokenRepository.blacklistRefreshJti(rJti, oldRttl);
+            tokenRepositoryPort.blacklistRefreshJti(rJti, oldRttl);
         }
-        tokenRepository.deleteRefreshTokenByJti(rJti);
-        tokenRepository.removeUserRefreshIndex(userId, rJti);
+        tokenRepositoryPort.deleteRefreshTokenByJti(rJti);
+        tokenRepositoryPort.removeUserRefreshIndex(userId, rJti);
 
         // 3) 새 토큰 발급 및 저장
         String newAccess = jwtProvider.generateAccessToken(user.getUserId(), user.getUserRole());
@@ -183,7 +184,7 @@ public class UserService implements UserUseCase {
         long refreshTtlMs = jwtProvider.refreshTokenTtlOf(newRefresh).toMillis();
 
         String newRHash = TokenHash.sha256(newRefresh);
-        tokenRepository.saveRefreshToken(newRJti, userId, newRHash, refreshTtlMs);
+        tokenRepositoryPort.saveRefreshToken(newRJti, userId, newRHash, refreshTtlMs);
 
         // 4) 응답
         return SignInResponse.of(user, newAccess, accessTtlMs, newRefresh, refreshTtlMs);
@@ -240,7 +241,7 @@ public class UserService implements UserUseCase {
             String aJti = jwtProvider.getJti(authorizationHeader);
             long aTtlMs = jwtProvider.accessTokenTtlOf(authorizationHeader).toMillis();
             if (aTtlMs > 0) {
-                tokenRepository.blacklistAccessJti(aJti, aTtlMs); // setIfAbsent로 TTL 연장 방지
+                tokenRepositoryPort.blacklistAccessJti(aJti, aTtlMs); // setIfAbsent로 TTL 연장 방지
             }
         } catch (TokenException ignore) {
             // AT 만료/형식 오류 등은 무시 (주 목적은 RT 폐기)
@@ -253,19 +254,19 @@ public class UserService implements UserUseCase {
     private void revokeRefreshByJti(Long userId, String rJti, String inputRefreshHash,
             long refreshTtlMs) {
         // 1) 멱등/위변조 방지: 저장된 해시와 비교 (저장소에 없으면 이미 처리된 것으로 간주)
-        String storedHash = tokenRepository.getRefreshTokenHashByJti(rJti).orElse(null);
+        String storedHash = tokenRepositoryPort.getRefreshTokenHashByJti(rJti).orElse(null);
         if (storedHash != null && !storedHash.equals(inputRefreshHash)) {
             throw new TokenException(JwtErrorCode.TAMPERED_TOKEN);
         }
 
         // 2) 블랙리스트 (TTL 있을 때만)
         if (refreshTtlMs > 0) {
-            tokenRepository.blacklistRefreshJti(rJti, refreshTtlMs);
+            tokenRepositoryPort.blacklistRefreshJti(rJti, refreshTtlMs);
         }
 
         // 3) 저장소 삭제 + 인덱스 제거
-        tokenRepository.deleteRefreshTokenByJti(rJti);
-        tokenRepository.removeUserRefreshIndex(userId, rJti);
+        tokenRepositoryPort.deleteRefreshTokenByJti(rJti);
+        tokenRepositoryPort.removeUserRefreshIndex(userId, rJti);
     }
 
     /**
@@ -273,17 +274,17 @@ public class UserService implements UserUseCase {
      */
     private void revokeAllRefreshOfUser(Long targetUserId) {
         // 1) rJti 전부 꺼내면서 인덱스 비우기 (원자)
-        Set<String> rJtis = tokenRepository.popAllUserRefreshJtis(targetUserId);
+        Set<String> rJtis = tokenRepositoryPort.popAllUserRefreshJtis(targetUserId);
         if (rJtis.isEmpty()) {
             return;
         }
 
         // 2) TTL 일괄 조회(파이프라인)
-        Map<String, Long> jtiToTtl = tokenRepository.mgetRemainingRefreshTtlsMs(rJtis);
+        Map<String, Long> jtiToTtl = tokenRepositoryPort.mgetRemainingRefreshTtlsMs(rJtis);
         // 3) 블랙리스트 일괄 등록(파이프라인) – TTL 있는 것만
-        tokenRepository.mblacklistRefreshJtis(jtiToTtl);
+        tokenRepositoryPort.mblacklistRefreshJtis(jtiToTtl);
         // 4) RT 해시 일괄 삭제(파이프라인)
-        tokenRepository.mdeleteRefreshTokensByJtis(rJtis);
+        tokenRepositoryPort.mdeleteRefreshTokensByJtis(rJtis);
     }
 
     // ---- 이메일 인증 코드 요청 ----
@@ -293,17 +294,17 @@ public class UserService implements UserUseCase {
         final String email = request.email();
 
         // 이미 가입된 이메일이면 굳이 인증코드 발송 X (정책에 따라 허용 가능)
-        if (userRepository.existsByEmail(email)) {
+        if (userRepositoryPort.existsByEmail(email)) {
             throw new UserException(UserErrorCode.EMAIL_DUPLICATED);
         }
 
         // 차단 상태 체크
-        if (emailRepo.isBlocked(email)) {
+        if (emailVerificationRepositoryPort.isBlocked(email)) {
             throw new UserException(UserErrorCode.EMAIL_VERIFICATION_BLOCKED);
         }
 
         // 쿨타임 체크
-        if (emailRepo.inCooltime(email)) {
+        if (emailVerificationRepositoryPort.inCooltime(email)) {
             throw new UserException(UserErrorCode.EMAIL_VERIFICATION_COOLTIME);
         }
 
@@ -312,17 +313,17 @@ public class UserService implements UserUseCase {
 
         // 코드 해시 저장
         String codeHash = TokenHash.sha256(code);
-        emailRepo.saveCodeHash(email, codeHash, emailProps.getCodeTtl());
+        emailVerificationRepositoryPort.saveCodeHash(email, codeHash, emailPolicy.codeTtl());
 
         // 쿨타임 세팅
-        emailRepo.setCooltime(email, emailProps.getCooltime());
+        emailVerificationRepositoryPort.setCooltime(email, emailPolicy.cooltime());
 
         // 메일 발송
-        thymeleafEmailSender.sendVerificationCode(email, code, emailProps.getCodeTtl(),
+        emailSenderPort.sendVerificationCode(email, code, emailPolicy.codeTtl(),
                 "Community SOAP");
 
         // 응답
-        long expireMs = emailProps.getCodeTtl().toMillis();
+        long expireMs = emailPolicy.codeTtl().toMillis();
         return EmailVerificationCodeResponse.of(email, expireMs);
     }
 
@@ -331,30 +332,31 @@ public class UserService implements UserUseCase {
     public void emailVerifyCode(EmailVerifyCodeRequest request) {
         final String email = request.email();
 
-        if (emailRepo.isBlocked(email)) {
+        if (emailVerificationRepositoryPort.isBlocked(email)) {
             throw new UserException(UserErrorCode.EMAIL_VERIFICATION_BLOCKED);
         }
 
-        String storedHash = emailRepo.getCodeHash(email)
+        String storedHash = emailVerificationRepositoryPort.getCodeHash(email)
                 .orElseThrow(
                         () -> new UserException(UserErrorCode.EMAIL_VERIFICATION_NOT_REQUESTED));
 
         String inputHash = TokenHash.sha256(String.valueOf(request.verifyCode()));
 
         if (!storedHash.equals(inputHash)) {
-            long attempts = emailRepo.incrementAttempts(email, emailProps.getCodeTtl());
-            if (attempts >= emailProps.getMaxAttempts()) {
-                emailRepo.block(email, emailProps.getBlockTtl());
-                emailRepo.deleteCode(email); // 코드 폐기
+            long attempts = emailVerificationRepositoryPort.incrementAttempts(email,
+                    emailPolicy.codeTtl());
+            if (attempts >= emailPolicy.maxAttempts()) {
+                emailVerificationRepositoryPort.block(email, emailPolicy.blockTtl());
+                emailVerificationRepositoryPort.deleteCode(email); // 코드 폐기
             }
             throw new UserException(UserErrorCode.EMAIL_VERIFY_CODE_MISMATCH);
         }
 
         // 성공: 코드/시도 수/블록 정보 정리
-        emailRepo.deleteCode(email);
-        emailRepo.resetAttempts(email);
-        emailRepo.clearVerified(email);     // 기존 플래그 제거 후
-        emailRepo.markVerified(email, emailProps.getVerifiedTtl());
+        emailVerificationRepositoryPort.deleteCode(email);
+        emailVerificationRepositoryPort.resetAttempts(email);
+        emailVerificationRepositoryPort.clearVerified(email);     // 기존 플래그 제거 후
+        emailVerificationRepositoryPort.markVerified(email, emailPolicy.verifiedTtl());
     }
 
     private String generate6DigitCode() {

--- a/src/main/java/com/community/soap/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/community/soap/user/domain/exception/UserErrorCode.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.application.exception;
+package com.community.soap.user.domain.exception;
 
 import com.community.soap.common.exception.ErrorCode;
 import lombok.Getter;

--- a/src/main/java/com/community/soap/user/domain/exception/UserException.java
+++ b/src/main/java/com/community/soap/user/domain/exception/UserException.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.application.exception;
+package com.community.soap.user.domain.exception;
 
 import com.community.soap.common.exception.AppException;
 

--- a/src/main/java/com/community/soap/user/infrastructure/email/EmailSenderAdapter.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/EmailSenderAdapter.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.persistence.external.email;
+package com.community.soap.user.infrastructure.email;
 
 
 import lombok.RequiredArgsConstructor;
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class EmailSender {
+public class EmailSenderAdapter {
 
     private final JavaMailSender mailSender;
 

--- a/src/main/java/com/community/soap/user/infrastructure/email/EmailVerificationRepositoryAdapter.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/EmailVerificationRepositoryAdapter.java
@@ -1,6 +1,6 @@
-package com.community.soap.user.persistence.external.naver;
+package com.community.soap.user.infrastructure.email;
 
-import com.community.soap.user.domain.repository.EmailVerificationRepository;
+import com.community.soap.user.application.port.out.EmailVerificationRepositoryPort;
 import java.time.Duration;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class RedisEmailVerificationRepository implements EmailVerificationRepository {
+public class EmailVerificationRepositoryAdapter implements EmailVerificationRepositoryPort {
 
     private final StringRedisTemplate redis;
 

--- a/src/main/java/com/community/soap/user/infrastructure/email/HtmlEmailSenderAdapter.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/HtmlEmailSenderAdapter.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.persistence.external.email;
+package com.community.soap.user.infrastructure.email;
 
 import jakarta.mail.internet.MimeMessage;
 import java.time.Duration;
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class HtmlEmailSender {
+public class HtmlEmailSenderAdapter {
 
     private final JavaMailSender mailSender;
 

--- a/src/main/java/com/community/soap/user/infrastructure/email/MailTemplateRenderer.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/MailTemplateRenderer.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.persistence.external.email;
+package com.community.soap.user.infrastructure.email;
 
 import java.util.Locale;
 import java.util.Map;

--- a/src/main/java/com/community/soap/user/infrastructure/email/ThymeleafEmailSenderAdapter.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/ThymeleafEmailSenderAdapter.java
@@ -1,5 +1,6 @@
-package com.community.soap.user.persistence.external.email;
+package com.community.soap.user.infrastructure.email;
 
+import com.community.soap.user.application.port.out.EmailSenderPort;
 import jakarta.mail.internet.InternetAddress;
 import java.time.Duration;
 import java.util.Map;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ThymeleafEmailSender {
+public class ThymeleafEmailSenderAdapter implements EmailSenderPort {
 
     private final JavaMailSender mailSender;
     private final MailTemplateRenderer renderer;

--- a/src/main/java/com/community/soap/user/infrastructure/email/config/EmailVerificationPolicyConfig.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/config/EmailVerificationPolicyConfig.java
@@ -1,0 +1,37 @@
+package com.community.soap.user.infrastructure.email.config;
+
+import com.community.soap.user.application.policy.EmailVerificationPolicy;
+import java.time.Duration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(EmailVerificationProperties.class)
+public class EmailVerificationPolicyConfig {
+
+    @Bean
+    public EmailVerificationPolicy emailVerificationPolicy(EmailVerificationProperties p) {
+        return new EmailVerificationPolicy() {
+            public Duration codeTtl() {
+                return p.getCodeTtl();
+            }
+
+            public Duration cooltime() {
+                return p.getCooltime();
+            }
+
+            public Duration blockTtl() {
+                return p.getBlockTtl();
+            }
+
+            public long maxAttempts() {
+                return p.getMaxAttempts();
+            }
+
+            public Duration verifiedTtl() {
+                return p.getVerifiedTtl();
+            }
+        };
+    }
+}

--- a/src/main/java/com/community/soap/user/infrastructure/email/config/EmailVerificationProperties.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/config/EmailVerificationProperties.java
@@ -1,24 +1,33 @@
-package com.community.soap.user.persistence.external.naver;
+package com.community.soap.user.infrastructure.email.config;
 
 import java.time.Duration;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 @Getter
 @Setter
-@Configuration
 @ConfigurationProperties(prefix = "auth.email")
 public class EmailVerificationProperties {
-    /** 코드 유효 시간 */
+
+    /**
+     * 코드 유효 시간
+     */
     private Duration codeTtl = Duration.ofMinutes(5);
-    /** 재전송 쿨타임 */
+    /**
+     * 재전송 쿨타임
+     */
     private Duration cooltime = Duration.ofSeconds(60);
-    /** 시도 횟수 제한(윈도우 TTL = codeTtl) */
+    /**
+     * 시도 횟수 제한(윈도우 TTL = codeTtl)
+     */
     private int maxAttempts = 5;
-    /** 차단 기간 */
+    /**
+     * 차단 기간
+     */
     private Duration blockTtl = Duration.ofMinutes(10);
-    /** 검증 성공 플래그 TTL */
+    /**
+     * 검증 성공 플래그 TTL
+     */
     private Duration verifiedTtl = Duration.ofMinutes(10);
 }

--- a/src/main/java/com/community/soap/user/infrastructure/email/config/MailTemplateConfig.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/config/MailTemplateConfig.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.persistence.external.email.config;
+package com.community.soap.user.infrastructure.email.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/community/soap/user/infrastructure/email/config/NaverEmailConfig.java
+++ b/src/main/java/com/community/soap/user/infrastructure/email/config/NaverEmailConfig.java
@@ -1,4 +1,4 @@
-package com.community.soap.user.persistence.external.email.config;
+package com.community.soap.user.infrastructure.email.config;
 
 import java.util.Properties;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/community/soap/user/infrastructure/jpa/JpaUserAdapter.java
+++ b/src/main/java/com/community/soap/user/infrastructure/jpa/JpaUserAdapter.java
@@ -1,0 +1,9 @@
+package com.community.soap.user.infrastructure.jpa;
+
+import com.community.soap.user.domain.entity.User;
+import com.community.soap.user.application.port.out.UserRepositoryPort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserAdapter extends JpaRepository<User, Long>, UserRepositoryPort {
+
+}

--- a/src/main/java/com/community/soap/user/infrastructure/jwt/JwtTokenStoreAdapter.java
+++ b/src/main/java/com/community/soap/user/infrastructure/jwt/JwtTokenStoreAdapter.java
@@ -1,6 +1,6 @@
-package com.community.soap.user.persistence;
+package com.community.soap.user.infrastructure.jwt;
 
-import com.community.soap.user.domain.repository.TokenRepository;
+import com.community.soap.user.application.port.out.TokenRepositoryPort;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
-public class JwtRepository implements TokenRepository {
+public class JwtTokenStoreAdapter implements TokenRepositoryPort {
 
     private final StringRedisTemplate redis;
 
@@ -92,7 +92,7 @@ public class JwtRepository implements TokenRepository {
         }
 
         // RT 본문 일괄 삭제
-        redis.delete(jtis.stream().map(JwtRepository::kRt).toList());
+        redis.delete(jtis.stream().map(JwtTokenStoreAdapter::kRt).toList());
         // 유저 인덱스 삭제
         redis.delete(kUserRt(userId));
 

--- a/src/main/java/com/community/soap/user/persistence/JpaUserRepository.java
+++ b/src/main/java/com/community/soap/user/persistence/JpaUserRepository.java
@@ -1,9 +1,0 @@
-package com.community.soap.user.persistence;
-
-import com.community.soap.user.domain.entity.User;
-import com.community.soap.user.domain.repository.UserRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface JpaUserRepository extends JpaRepository<User, Long>, UserRepository {
-
-}

--- a/src/main/java/com/community/soap/user/presentation/AuthController.java
+++ b/src/main/java/com/community/soap/user/presentation/AuthController.java
@@ -2,7 +2,7 @@ package com.community.soap.user.presentation;
 
 import com.community.soap.common.resolver.CurrentUser;
 import com.community.soap.common.resolver.CurrentUserInfo;
-import com.community.soap.user.application.UserUseCase;
+import com.community.soap.user.application.port.in.UserUseCase;
 import com.community.soap.user.application.request.EmailVerificationCodeRequest;
 import com.community.soap.user.application.request.EmailVerifyCodeRequest;
 import com.community.soap.user.application.request.LogoutRequest;

--- a/src/main/java/com/community/soap/user/presentation/AuthController.java
+++ b/src/main/java/com/community/soap/user/presentation/AuthController.java
@@ -53,11 +53,11 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<LogoutResponse> logout(
-            @RequestHeader(name = "Authorization", required = false) String authorization,
+            @RequestHeader(name = "Authorization", required = false) String authorizationHeader,
             @RequestBody @Valid LogoutRequest request,
             @CurrentUser CurrentUserInfo info
     ) {
-        userUseCase.logout(authorization, request.refreshToken(), info.userId());
+        userUseCase.logout(authorizationHeader, request.refreshToken(), info.userId());
         return ResponseEntity.ok(LogoutResponse.ok());
     }
 

--- a/src/main/java/com/community/soap/user/presentation/UserController.java
+++ b/src/main/java/com/community/soap/user/presentation/UserController.java
@@ -3,7 +3,7 @@ package com.community.soap.user.presentation;
 import com.community.soap.common.aop.Permission;
 import com.community.soap.common.resolver.CurrentUser;
 import com.community.soap.common.resolver.CurrentUserInfo;
-import com.community.soap.user.application.UserUseCase;
+import com.community.soap.user.application.port.in.UserUseCase;
 import com.community.soap.user.application.response.MyPageResponse;
 import com.community.soap.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/community/soap/user/presentation/UserController.java
+++ b/src/main/java/com/community/soap/user/presentation/UserController.java
@@ -27,7 +27,7 @@ public class UserController {
     public ResponseEntity<MyPageResponse> me(
             @CurrentUser CurrentUserInfo info
     ) {
-        MyPageResponse response = userUseCase.me(info);
+        MyPageResponse response = userUseCase.me(info.userId());
 
         return ResponseEntity
                 .status(HttpStatus.OK)


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [x] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- port / Adapter 도입으로 레이어드 아키텍처에서 부적절한 의존 관계를 해소했습니다.
- gitignore 에서 out 디렉토리는 루트에 위치하는 경우에만 제외하도록 변경했습니다.

## 🔍 관련 이슈
- Closes #29

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 이메일 인증 정책(code TTL, 쿨타임, 최대 시도, 차단/인증 유지기간) 설정을 지원해 인증 흐름의 일관성과 보안을 강화했습니다.
  - 인증 메일 발송을 위한 추상화(플러그형 발송자) 추가로 다양한 메일 전송 구현을 손쉽게 교체할 수 있게 했습니다.

- 리팩터링
  - 인증·이메일·토큰 저장소를 포트/어댑터 구조로 재구성해 모듈성과 테스트 편의성을 개선했습니다.
  - 컨트롤러와 서비스의 내부 의존성 경로를 정리했으나 외부 API 동작은 유지됩니다.

- 기타(Chores)
  - .gitignore 규칙을 루트 기준으로 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->