### PR TITLE
Catelog: 상품과 카테고리 CRUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.5'
 	id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+
 }
 
 group = 'com.community'
@@ -59,8 +61,15 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.named('asciidoctor') {
+    inputs.dir snippetsDir
+    dependsOn test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
@@ -67,6 +71,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+    outputs.dir snippetsDir
 }
 
 tasks.named('asciidoctor') {

--- a/src/main/java/com/community/soap/catalog/application/port/in/CategoryUseCase.java
+++ b/src/main/java/com/community/soap/catalog/application/port/in/CategoryUseCase.java
@@ -1,0 +1,20 @@
+package com.community.soap.catalog.application.port.in;
+
+import com.community.soap.catalog.application.request.category.CreateCategoryRequest;
+import com.community.soap.catalog.application.request.category.UpdateCategoryRequest;
+import com.community.soap.catalog.application.response.category.CreateCategoryResponse;
+import com.community.soap.catalog.application.response.category.GetCategoriesResponse;
+import com.community.soap.catalog.application.response.category.UpdateCategoryResponse;
+import com.community.soap.common.util.PageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface CategoryUseCase {
+
+    CreateCategoryResponse createCategory(Long userId, CreateCategoryRequest request);
+
+    PageResponse<GetCategoriesResponse> getCategories(String q, Pageable pageable, boolean all);
+
+    UpdateCategoryResponse updateCategory(Long userId, Long categoryId, UpdateCategoryRequest request);
+
+    void softDeleteCategory(Long userId, Long categoryId);
+}

--- a/src/main/java/com/community/soap/catalog/application/port/in/ProductUseCase.java
+++ b/src/main/java/com/community/soap/catalog/application/port/in/ProductUseCase.java
@@ -7,7 +7,6 @@ import com.community.soap.catalog.application.request.product.ProductSearchCondi
 import com.community.soap.catalog.application.request.product.UpdateProductRequest;
 import com.community.soap.catalog.application.response.product.CreateProductResponse;
 import com.community.soap.catalog.application.response.product.GetProductResponse;
-import com.community.soap.catalog.application.response.product.IncreaseProductResponse;
 import com.community.soap.common.util.PageResponse;
 
 public interface ProductUseCase {

--- a/src/main/java/com/community/soap/catalog/application/port/in/ProductUseCase.java
+++ b/src/main/java/com/community/soap/catalog/application/port/in/ProductUseCase.java
@@ -1,0 +1,28 @@
+package com.community.soap.catalog.application.port.in;
+
+import com.community.soap.catalog.application.request.product.CreateProductRequest;
+import com.community.soap.catalog.application.request.product.DecreaseProductRequest;
+import com.community.soap.catalog.application.request.product.IncreaseProductRequest;
+import com.community.soap.catalog.application.request.product.ProductSearchCondition;
+import com.community.soap.catalog.application.request.product.UpdateProductRequest;
+import com.community.soap.catalog.application.response.product.CreateProductResponse;
+import com.community.soap.catalog.application.response.product.GetProductResponse;
+import com.community.soap.catalog.application.response.product.IncreaseProductResponse;
+import com.community.soap.common.util.PageResponse;
+
+public interface ProductUseCase {
+
+    CreateProductResponse createProduct(CreateProductRequest request);
+
+    GetProductResponse getProductDetail(Long productId);
+
+    PageResponse<GetProductResponse> getProducts(ProductSearchCondition condition);
+
+    GetProductResponse increaseProduct(Long productId, IncreaseProductRequest request);
+
+    GetProductResponse decreaseProduct(Long productId, DecreaseProductRequest request);
+
+    GetProductResponse updateProduct(Long productId, UpdateProductRequest request);
+
+    void softDeleteProduct(Long productId, UpdateProductRequest request);
+}

--- a/src/main/java/com/community/soap/catalog/application/port/out/CategoryRepositoryPort.java
+++ b/src/main/java/com/community/soap/catalog/application/port/out/CategoryRepositoryPort.java
@@ -1,0 +1,25 @@
+package com.community.soap.catalog.application.port.out;
+
+import com.community.soap.catalog.domain.entity.Category;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CategoryRepositoryPort {
+
+    boolean existsByName(String name);
+
+    Page<Category> findByIsDeletedFalse(Pageable pageable);
+
+    Page<Category> findByIsDeletedFalseAndNameContainingIgnoreCase(String q, Pageable pageable);
+
+    // 전체 조회(ALL 용)
+    List<Category> findByIsDeletedFalseOrderByCreatedAtDesc();
+
+    List<Category> findByIsDeletedFalseAndNameContainingIgnoreCaseOrderByCreatedAtDesc(String q);
+
+    Category save(Category category);
+
+    Optional<Category> findById(Long categoryId);
+}

--- a/src/main/java/com/community/soap/catalog/application/port/out/ProductRepositoryPort.java
+++ b/src/main/java/com/community/soap/catalog/application/port/out/ProductRepositoryPort.java
@@ -1,0 +1,16 @@
+package com.community.soap.catalog.application.port.out;
+
+import com.community.soap.catalog.application.request.product.ProductSearchCondition;
+import com.community.soap.catalog.domain.entity.Product;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductRepositoryPort {
+    Product save(Product product);
+    boolean existsBySkuCode(String code);
+    Optional<Product> findById(Long productId);
+
+    boolean existsByProductId(Long productId);
+    Page<Product> findAllByCondition(ProductSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/community/soap/catalog/application/request/category/CreateCategoryRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/category/CreateCategoryRequest.java
@@ -1,0 +1,8 @@
+package com.community.soap.catalog.application.request.category;
+
+public record CreateCategoryRequest(
+        String name,
+        String description
+) {
+
+}

--- a/src/main/java/com/community/soap/catalog/application/request/category/UpdateCategoryRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/category/UpdateCategoryRequest.java
@@ -1,0 +1,8 @@
+package com.community.soap.catalog.application.request.category;
+
+public record UpdateCategoryRequest(
+        String newName,
+        String newDescription
+) {
+
+}

--- a/src/main/java/com/community/soap/catalog/application/request/product/CreateProductRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/product/CreateProductRequest.java
@@ -1,0 +1,18 @@
+package com.community.soap.catalog.application.request.product;
+
+import com.community.soap.catalog.domain.entity.ProductStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record CreateProductRequest(
+        @NotBlank String name,
+        @NotBlank String description,
+        @NotNull Long categoryId,
+        @NotNull ProductStatus productStatus,
+        @NotBlank String skuCode,
+        @NotNull @PositiveOrZero Integer price,
+        @NotNull @PositiveOrZero Integer stock
+) {
+
+}

--- a/src/main/java/com/community/soap/catalog/application/request/product/DecreaseProductRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/product/DecreaseProductRequest.java
@@ -1,9 +1,10 @@
 package com.community.soap.catalog.application.request.product;
 
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record DecreaseProductRequest(
-        @PositiveOrZero Integer quantity
+        @NotNull @Positive Integer quantity
 ) {
 
 }

--- a/src/main/java/com/community/soap/catalog/application/request/product/DecreaseProductRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/product/DecreaseProductRequest.java
@@ -1,0 +1,9 @@
+package com.community.soap.catalog.application.request.product;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record DecreaseProductRequest(
+        @PositiveOrZero Integer quantity
+) {
+
+}

--- a/src/main/java/com/community/soap/catalog/application/request/product/IncreaseProductRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/product/IncreaseProductRequest.java
@@ -1,9 +1,10 @@
 package com.community.soap.catalog.application.request.product;
 
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record IncreaseProductRequest(
-        @PositiveOrZero Integer quantity
+        @NotNull @Positive Integer quantity
 ) {
 
 }

--- a/src/main/java/com/community/soap/catalog/application/request/product/IncreaseProductRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/product/IncreaseProductRequest.java
@@ -1,0 +1,9 @@
+package com.community.soap.catalog.application.request.product;
+
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record IncreaseProductRequest(
+        @PositiveOrZero Integer quantity
+) {
+
+}

--- a/src/main/java/com/community/soap/catalog/application/request/product/ProductSearchCondition.java
+++ b/src/main/java/com/community/soap/catalog/application/request/product/ProductSearchCondition.java
@@ -1,0 +1,30 @@
+package com.community.soap.catalog.application.request.product;
+
+import org.springframework.util.StringUtils;
+
+public record ProductSearchCondition(
+        Long categoryId,
+        Integer minPrice,
+        Integer maxPrice,
+        String keyword,   // 상품명 검색(부분)
+        String sort,      // createdAt | name | price   (컬럼 매핑은 서비스에서)
+        String order,     // asc | desc
+        Integer page,     // 0-base
+        Integer size      // page size
+) {
+
+    public boolean hasKeyword() {
+        return StringUtils.hasText(keyword);
+    }
+
+    public String normalizedSort() {
+        return switch (sort == null ? "" : sort) {
+            case "name", "price", "createdAt" -> sort;
+            default -> "createdAt";
+        };
+    }
+
+    public String normalizedOrder() {
+        return "asc".equalsIgnoreCase(order) ? "asc" : "desc";
+    }
+}

--- a/src/main/java/com/community/soap/catalog/application/request/product/UpdateProductRequest.java
+++ b/src/main/java/com/community/soap/catalog/application/request/product/UpdateProductRequest.java
@@ -1,0 +1,15 @@
+package com.community.soap.catalog.application.request.product;
+
+import com.community.soap.catalog.domain.entity.ProductStatus;
+
+public record UpdateProductRequest(
+        String name,
+        String description,
+        Long categoryId,
+        ProductStatus productStatus,
+        String skuCode,
+        Integer price,
+        Integer stock
+) {
+
+}

--- a/src/main/java/com/community/soap/catalog/application/response/category/CreateCategoryResponse.java
+++ b/src/main/java/com/community/soap/catalog/application/response/category/CreateCategoryResponse.java
@@ -1,0 +1,32 @@
+package com.community.soap.catalog.application.response.category;
+
+import com.community.soap.catalog.domain.entity.Category;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record CreateCategoryResponse(
+        Long categoryId,
+        String name,
+        String description,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        Long createdBy,
+        LocalDateTime updatedAt,
+        Long updatedBy
+) {
+
+    public static CreateCategoryResponse from(Category category) {
+        return CreateCategoryResponse.builder()
+                .categoryId(category.getCategoryId())
+                .name(category.getName())
+                .description(category.getDescription())
+                .isDeleted(category.getIsDeleted())
+                .createdAt(category.getCreatedAt())
+                .createdBy(category.getCreatedBy())
+                .updatedAt(category.getUpdatedAt())
+                .updatedBy(category.getUpdatedBy())
+                .build();
+    }
+}

--- a/src/main/java/com/community/soap/catalog/application/response/category/GetCategoriesResponse.java
+++ b/src/main/java/com/community/soap/catalog/application/response/category/GetCategoriesResponse.java
@@ -1,0 +1,30 @@
+package com.community.soap.catalog.application.response.category;
+
+import com.community.soap.catalog.domain.entity.Category;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetCategoriesResponse(
+        Long categoryId,
+        String name,
+        String description,
+        LocalDateTime createdAt,
+        Long createdBy,
+        LocalDateTime updatedAt,
+        Long updatedBy
+) {
+
+    public static GetCategoriesResponse from(Category category) {
+        return GetCategoriesResponse.builder()
+                .categoryId(category.getCategoryId())
+                .name(category.getName())
+                .description(category.getDescription())
+                .createdAt(category.getCreatedAt())
+                .createdBy(category.getCreatedBy())
+                .updatedAt(category.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/community/soap/catalog/application/response/category/UpdateCategoryResponse.java
+++ b/src/main/java/com/community/soap/catalog/application/response/category/UpdateCategoryResponse.java
@@ -1,0 +1,33 @@
+package com.community.soap.catalog.application.response.category;
+
+import com.community.soap.catalog.domain.entity.Category;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UpdateCategoryResponse(
+        Long categoryId,
+        String name,
+        String description,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        Long createdBy,
+        LocalDateTime updatedAt,
+        Long updatedBy
+
+) {
+
+    public static UpdateCategoryResponse from(Category category) {
+        return UpdateCategoryResponse.builder()
+                .categoryId(category.getCategoryId())
+                .name(category.getName())
+                .description(category.getDescription())
+                .isDeleted(category.getIsDeleted())
+                .createdAt(category.getCreatedAt())
+                .createdBy(category.getCreatedBy())
+                .updatedAt(category.getUpdatedAt())
+                .updatedBy(category.getUpdatedBy())
+                .build();
+    }
+}

--- a/src/main/java/com/community/soap/catalog/application/response/product/CreateProductResponse.java
+++ b/src/main/java/com/community/soap/catalog/application/response/product/CreateProductResponse.java
@@ -1,0 +1,53 @@
+package com.community.soap.catalog.application.response.product;
+
+import com.community.soap.catalog.domain.entity.Product;
+import com.community.soap.catalog.domain.entity.ProductStatus;
+import com.community.soap.catalog.domain.entity.Sku;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record CreateProductResponse(
+        Long productId,
+        String name,
+        String description,
+        Long categoryId,
+        ProductStatus productStatus,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        Long createdBy,
+        SkUnit skUnit
+) {
+
+    public static CreateProductResponse from(Product product) {
+        return CreateProductResponse.builder()
+                .productId(product.getProductId())
+                .name(product.getName())
+                .description(product.getDescription())
+                .categoryId(product.getCategoryId())
+                .productStatus(product.getProductStatus())
+                .isDeleted(product.getIsDeleted())
+                .createdAt(product.getCreatedAt())
+                .createdBy(product.getCreatedBy())
+                .skUnit(SkUnit.from(product.getSku()))
+                .build();
+    }
+
+
+    @Builder(access = AccessLevel.PRIVATE)
+    protected record SkUnit(
+            String skuCode,
+            Integer price,
+            Integer stock
+    ) {
+
+        public static SkUnit from(Sku sku) {
+            return SkUnit.builder()
+                    .skuCode(sku.getCode())
+                    .price(sku.getPrice())
+                    .stock(sku.getStock())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/community/soap/catalog/application/response/product/GetProductResponse.java
+++ b/src/main/java/com/community/soap/catalog/application/response/product/GetProductResponse.java
@@ -1,0 +1,53 @@
+package com.community.soap.catalog.application.response.product;
+
+import com.community.soap.catalog.domain.entity.Product;
+import com.community.soap.catalog.domain.entity.ProductStatus;
+import com.community.soap.catalog.domain.entity.Sku;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetProductResponse(
+        Long productId,
+        String name,
+        String description,
+        Long categoryId,
+        ProductStatus productStatus,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        Long createdBy,
+        SkUnit skUnit
+) {
+
+    public static GetProductResponse from(Product product) {
+        return GetProductResponse.builder()
+                .productId(product.getProductId())
+                .name(product.getName())
+                .description(product.getDescription())
+                .categoryId(product.getCategoryId())
+                .productStatus(product.getProductStatus())
+                .isDeleted(product.getIsDeleted())
+                .createdAt(product.getCreatedAt())
+                .createdBy(product.getCreatedBy())
+                .skUnit(SkUnit.from(product.getSku()))
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    protected record SkUnit(
+            String skuCode,
+            Integer price,
+            Integer stock
+    ) {
+
+        public static GetProductResponse.SkUnit from(Sku sku) {
+            return GetProductResponse.SkUnit.builder()
+                    .skuCode(sku.getCode())
+                    .price(sku.getPrice())
+                    .stock(sku.getStock())
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/com/community/soap/catalog/application/response/product/IncreaseProductResponse.java
+++ b/src/main/java/com/community/soap/catalog/application/response/product/IncreaseProductResponse.java
@@ -1,0 +1,5 @@
+package com.community.soap.catalog.application.response.product;
+
+public record IncreaseProductResponse() {
+
+}

--- a/src/main/java/com/community/soap/catalog/application/service/CategoryService.java
+++ b/src/main/java/com/community/soap/catalog/application/service/CategoryService.java
@@ -94,11 +94,11 @@ public class CategoryService implements CategoryUseCase {
             UpdateCategoryRequest request) {
         Category findCategory = findByCategoryId(categoryId);
 
-        if (!request.newName().isBlank()) {
-            findCategory.updateName(userId, request.newName());
+        if (request.newName() != null && !request.newName().isBlank()) {
+            findCategory.updateName(userId, request.newName().trim());
         }
 
-        if (!request.newDescription().isBlank()) {
+        if (request.newDescription() != null && !request.newDescription().isBlank()) {
             findCategory.updateDescription(userId, request.newDescription());
         }
 

--- a/src/main/java/com/community/soap/catalog/application/service/CategoryService.java
+++ b/src/main/java/com/community/soap/catalog/application/service/CategoryService.java
@@ -1,0 +1,116 @@
+package com.community.soap.catalog.application.service;
+
+import com.community.soap.catalog.application.port.in.CategoryUseCase;
+import com.community.soap.catalog.application.port.out.CategoryRepositoryPort;
+import com.community.soap.catalog.application.request.category.CreateCategoryRequest;
+import com.community.soap.catalog.application.request.category.UpdateCategoryRequest;
+import com.community.soap.catalog.application.response.category.CreateCategoryResponse;
+import com.community.soap.catalog.application.response.category.GetCategoriesResponse;
+import com.community.soap.catalog.application.response.category.UpdateCategoryResponse;
+import com.community.soap.catalog.domain.entity.Category;
+import com.community.soap.catalog.domain.exception.CategoryErrorCode;
+import com.community.soap.catalog.domain.exception.CategoryException;
+import com.community.soap.common.snowflake.Snowflake;
+import com.community.soap.common.util.PageResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j(topic = "CategoryService")
+@RequiredArgsConstructor
+@Service
+public class CategoryService implements CategoryUseCase {
+
+    private final CategoryRepositoryPort categoryRepositoryPort;
+    private final Snowflake snowflake;
+
+    public void existsByName(String name) {
+        if (categoryRepositoryPort.existsByName(name)) {
+            throw new CategoryException(CategoryErrorCode.CATEGORY_NAME_DUPLICATED);
+        }
+    }
+
+    public Category findByCategoryId(Long categoryId) {
+        return categoryRepositoryPort.findById(categoryId)
+                .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    @Transactional
+    @Override
+    public CreateCategoryResponse createCategory(Long userId, CreateCategoryRequest request) {
+        existsByName(request.name());
+
+        Category category = Category.of(
+                snowflake.nextId(),
+                request.name(),
+                request.description(),
+                userId
+        );
+
+        Category save = categoryRepositoryPort.save(category);
+
+        return CreateCategoryResponse.from(save);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public PageResponse<GetCategoriesResponse> getCategories(
+            String q,
+            Pageable pageable,
+            boolean all) {
+        if (all) {
+            // 전체 보기
+            List<Category> list = (q == null || q.isBlank())
+                    ? categoryRepositoryPort.findByIsDeletedFalseOrderByCreatedAtDesc()
+                    : categoryRepositoryPort.findByIsDeletedFalseAndNameContainingIgnoreCaseOrderByCreatedAtDesc(
+                            q);
+
+            return new PageResponse<>(
+                    list.stream().map(GetCategoriesResponse::from).toList(),
+                    0, // 0부터 시작
+                    list.size(),
+                    list.size(),
+                    1, // 카테고리 페이징 1까지만 설정
+                    true
+            );
+        }
+        Page<Category> page = (q == null || q.isBlank())
+                ? categoryRepositoryPort.findByIsDeletedFalse(pageable)
+                : categoryRepositoryPort.findByIsDeletedFalseAndNameContainingIgnoreCase(q,
+                        pageable);
+
+        Page<GetCategoriesResponse> mapped = page.map(GetCategoriesResponse::from);
+        return PageResponse.from(mapped);
+
+    }
+
+    @Transactional
+    @Override
+    public UpdateCategoryResponse updateCategory(Long userId, Long categoryId,
+            UpdateCategoryRequest request) {
+        Category findCategory = findByCategoryId(categoryId);
+
+        if (!request.newName().isBlank()) {
+            findCategory.updateName(userId, request.newName());
+        }
+
+        if (!request.newDescription().isBlank()) {
+            findCategory.updateDescription(userId, request.newDescription());
+        }
+
+        return UpdateCategoryResponse.from(findCategory);
+    }
+
+    @Transactional
+    @Override
+    public void softDeleteCategory(Long userId, Long categoryId) {
+        Category byCategoryId = findByCategoryId(categoryId);
+
+        byCategoryId.updateIsDeleted(userId, true);
+    }
+}
+

--- a/src/main/java/com/community/soap/catalog/application/service/ProductService.java
+++ b/src/main/java/com/community/soap/catalog/application/service/ProductService.java
@@ -1,0 +1,182 @@
+package com.community.soap.catalog.application.service;
+
+import com.community.soap.catalog.application.port.in.ProductUseCase;
+import com.community.soap.catalog.application.port.out.ProductRepositoryPort;
+import com.community.soap.catalog.application.request.product.CreateProductRequest;
+import com.community.soap.catalog.application.request.product.DecreaseProductRequest;
+import com.community.soap.catalog.application.request.product.IncreaseProductRequest;
+import com.community.soap.catalog.application.request.product.ProductSearchCondition;
+import com.community.soap.catalog.application.request.product.UpdateProductRequest;
+import com.community.soap.catalog.application.response.product.CreateProductResponse;
+import com.community.soap.catalog.application.response.product.GetProductResponse;
+import com.community.soap.catalog.domain.entity.Product;
+import com.community.soap.catalog.domain.entity.Sku;
+import com.community.soap.catalog.domain.exception.ProductErrorCode;
+import com.community.soap.catalog.domain.exception.ProductException;
+import com.community.soap.common.snowflake.Snowflake;
+import com.community.soap.common.util.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ProductService implements ProductUseCase {
+
+    private final Snowflake snowflake;
+    private final ProductRepositoryPort productRepositoryPort;
+
+    private void existsBySkuCode(String skuCode) {
+        if (productRepositoryPort.existsBySkuCode(skuCode)) {
+            throw new ProductException(ProductErrorCode.SKU_CODE_DUPLICATED);
+        }
+    }
+
+    private void existsByProductId(Long productId) {
+        if (!productRepositoryPort.existsByProductId(productId)) {
+            throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
+        }
+    }
+
+    private Product findProductByProductId(Long productId) {
+        return productRepositoryPort.findById(productId)
+                .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    private void assertUpdatable(Product p) {
+        if (Boolean.TRUE.equals(p.getIsDeleted())) {
+            throw new ProductException(ProductErrorCode.PRODUCT_SOFT_DELETED);
+        }
+    }
+
+    @Transactional
+    @Override
+    public CreateProductResponse createProduct(CreateProductRequest request) {
+        existsBySkuCode(request.skuCode());
+
+        Sku sku = Sku.of(
+                request.skuCode(),
+                request.price(),
+                request.stock()
+        );
+
+        Product product = Product.of(
+                snowflake.nextId(),
+                request.name(),
+                request.description(),
+                request.categoryId(),
+                request.productStatus(),
+                sku,
+                0L
+        );
+
+        Product saved = productRepositoryPort.save(product);
+
+        return CreateProductResponse.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public GetProductResponse getProductDetail(Long productId) {
+        existsByProductId(productId);
+        Product productById = findProductByProductId(productId);
+
+        return GetProductResponse.from(productById);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public PageResponse<GetProductResponse> getProducts(ProductSearchCondition c) {
+        int page = (c.page() == null || c.page() < 0) ? 0 : c.page();
+        int size = (c.size() == null || c.size() <= 0) ? 20 : Math.min(c.size(), 200);
+
+        if (c.minPrice() != null && c.maxPrice() != null && c.maxPrice() < c.minPrice()) {
+            throw new ProductException(ProductErrorCode.INVALID_PRICE_RANGE);
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<GetProductResponse> pageResult = productRepositoryPort
+                .findAllByCondition(c, pageable)
+                .map(GetProductResponse::from);
+
+        return PageResponse.from(pageResult);
+    }
+
+    @Transactional
+    @Override
+    public GetProductResponse increaseProduct(Long productId, IncreaseProductRequest request) {
+        Product product = findProductByProductId(productId);
+        assertUpdatable(product);
+        product.getSku().increaseStock(request.quantity());
+
+        return GetProductResponse.from(product);
+    }
+
+
+    @Transactional
+    @Override
+    public GetProductResponse decreaseProduct(Long productId, DecreaseProductRequest request) {
+        Product product = findProductByProductId(productId);
+        assertUpdatable(product);
+        product.getSku().decreaseStock(request.quantity());
+
+        return GetProductResponse.from(product);
+    }
+
+    @Transactional
+    @Override
+    public GetProductResponse updateProduct(Long productId, UpdateProductRequest request) {
+        Product product = findProductByProductId(productId);
+        assertUpdatable(product); // 삭제/INACTIVE 등 업데이트 불가 가드
+
+        // (선택) 문자열 유효성 – 비어있으면 무시/에러 정책은 팀 규칙대로
+        if (request.name() != null && !request.name().isBlank()) {
+            product.changeName(request.name().trim());
+        }
+        if (request.description() != null && !request.description().isBlank()) {
+            product.changeDescription(request.description().trim());
+        }
+
+        if (request.categoryId() != null) {
+            product.changeCategory(request.categoryId());
+        }
+
+        if (request.productStatus() != null) {
+            product.changeStatus(request.productStatus());
+        }
+
+        // SKU 코드가 바뀌는 경우에만 중복 체크
+        if (request.skuCode() != null) {
+            String current = product.getSku().getCode();
+            if (!request.skuCode().equals(current)) {
+                if (productRepositoryPort.existsBySkuCode(request.skuCode())) {
+                    throw new ProductException(ProductErrorCode.SKU_CODE_DUPLICATED);
+                }
+            }
+        }
+
+        // 가격/재고/코드 중 들어온 값만 반영
+        if (request.skuCode() != null || request.price() != null || request.stock() != null) {
+            product.changeSku(request.skuCode(), request.price(), request.stock());
+        }
+
+        // 감사 필드
+        product.updatedBy(0L); // 실제 사용자 ID로 교체 (예: SecurityContext에서 꺼내기)
+
+        // 더티체킹으로 UPDATE 반영
+        return GetProductResponse.from(product);
+    }
+
+    @Transactional
+    @Override
+    public void softDeleteProduct(Long productId, UpdateProductRequest request) {
+        Product productById = findProductByProductId(productId);
+
+        productById.softDelete();
+        productById.updatedBy(0L);
+    }
+}

--- a/src/main/java/com/community/soap/catalog/domain/entity/Category.java
+++ b/src/main/java/com/community/soap/catalog/domain/entity/Category.java
@@ -1,5 +1,78 @@
 package com.community.soap.catalog.domain.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "s_category")
+@Entity
 public class Category {
 
+    @Id
+    @Column(name = "category_id", nullable = false)
+    private Long categoryId;
+
+    @Column(name = "name", nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "description", length = 1000)
+    private String description;
+
+    // TODO: 트리 구조는 나중에. 지금은 단일 계층만.
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = Boolean.FALSE;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    private Category(Long categoryId, String name, String description, Long createdBy) {
+        this.categoryId = categoryId;
+        this.name = name;
+        this.description = description;
+        this.isDeleted = Boolean.FALSE;
+        this.createdAt = LocalDateTime.now();
+        this.createdBy = createdBy;
+        this.updatedAt = null;
+        this.updatedBy = null;
+    }
+
+    public static Category of(Long categoryId, String name, String description, Long createdBy) {
+        return new Category(categoryId, name, description, createdBy);
+    }
+
+    public void updateName(Long userId, String newName) {
+        this.name = newName;
+        update(userId);
+    }
+
+    public void updateDescription(Long userId, String newDescription) {
+        this.description = newDescription;
+        update(userId);
+    }
+
+    public void updateIsDeleted(Long userId, Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+        update(userId);
+    }
+
+    private void update(Long userId) {
+        this.updatedAt = LocalDateTime.now();
+        this.updatedBy = userId;
+    }
 }

--- a/src/main/java/com/community/soap/catalog/domain/entity/Product.java
+++ b/src/main/java/com/community/soap/catalog/domain/entity/Product.java
@@ -1,5 +1,130 @@
 package com.community.soap.catalog.domain.entity;
 
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "s_product")
+@Entity
 public class Product {
 
+    @Id
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "product_status", nullable = false, length = 40)
+    private ProductStatus productStatus;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "code", column = @Column(name = "sku_code", nullable = false)),
+            @AttributeOverride(name = "price", column = @Column(name = "sku_price", nullable = false)),
+            @AttributeOverride(name = "stock", column = @Column(name = "sku_stock", nullable = false))
+    })
+    private Sku sku;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = Boolean.FALSE;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    private Product(
+            Long productId,
+            String name,
+            String description,
+            Long categoryId,
+            ProductStatus productStatus,
+            Sku sku,
+            Long createdBy) {
+        this.productId = productId;
+        this.name = name;
+        this.description = description;
+        this.categoryId = categoryId;
+        this.productStatus = productStatus;
+        this.sku = sku;
+        this.isDeleted = Boolean.FALSE;
+        this.createdAt = LocalDateTime.now();
+        this.createdBy = createdBy;
+        this.updatedAt = null;
+        this.updatedBy = null;
+    }
+
+    public static Product of(
+            Long productId,
+            String name,
+            String description,
+            Long categoryId,
+            ProductStatus productStatus,
+            Sku sku,
+            Long createdBy) {
+        return new Product(
+                productId,
+                name,
+                description,
+                categoryId,
+                productStatus,
+                sku,
+                createdBy);
+    }
+
+    public void updatedBy(Long userId) {
+        this.updatedBy = userId;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changeDescription(String description) {
+        this.description = description;
+    }
+
+    public void changeCategory(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public void changeStatus(ProductStatus status) {
+        this.productStatus = status;
+    }
+
+    public void changeSku(String code, Integer price, Integer stock) {
+        this.sku.apply(code, price, stock);
+    }
+
+    public void softDelete() {
+        this.isDeleted = Boolean.TRUE;
+    }
 }

--- a/src/main/java/com/community/soap/catalog/domain/entity/ProductStatus.java
+++ b/src/main/java/com/community/soap/catalog/domain/entity/ProductStatus.java
@@ -1,5 +1,11 @@
 package com.community.soap.catalog.domain.entity;
 
-public class ProductStatus {
+import lombok.Getter;
 
+
+@Getter
+public enum ProductStatus {
+    ACTIVE,     // 판매중
+    INACTIVE,   // 비활성 (진열 X)
+    OUT_OF_STOCK // 품절
 }

--- a/src/main/java/com/community/soap/catalog/domain/entity/Sku.java
+++ b/src/main/java/com/community/soap/catalog/domain/entity/Sku.java
@@ -1,5 +1,48 @@
 package com.community.soap.catalog.domain.entity;
 
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
 public class Sku {
 
+    // 가장 기본 값들만: 코드, 가격, 재고
+    private String code;
+    private Integer price;
+    private Integer stock;
+
+    public void increaseStock(int quantity) {
+        this.stock = (this.stock == null ? 0 : this.stock) + quantity;
+    }
+
+    public void decreaseStock(int quantity) {
+        int cur = (this.stock == null ? 0 : this.stock) - quantity;
+        this.stock = Math.max(cur, 0);
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Sku(String code, Integer price, Integer stock) {
+        this.code = code;
+        this.price = price;
+        this.stock = stock;
+    }
+
+    public static Sku of(String code, Integer price, Integer stock) {
+        return Sku.builder()
+                .code(code)
+                .price(price)
+                .stock(stock)
+                .build();
+    }
+
+    public void apply(String code, Integer price, Integer stock) {
+        if (code != null)  this.code = code;
+        if (price != null) this.price = price;
+        if (stock != null) this.stock = stock;
+    }
 }

--- a/src/main/java/com/community/soap/catalog/domain/exception/CategoryErrorCode.java
+++ b/src/main/java/com/community/soap/catalog/domain/exception/CategoryErrorCode.java
@@ -1,0 +1,19 @@
+package com.community.soap.catalog.domain.exception;
+
+import com.community.soap.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+    CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "카테고리: 잘못된 카테고리 정보입니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리: 카테고리 정보를 찾을 수 없습니다."),
+    CATEGORY_NAME_DUPLICATED(HttpStatus.CONFLICT, "카테고리: 이미 사용 중인 카테고리명입니다."),
+    CATEGORY_NAME_INVALID(HttpStatus.BAD_REQUEST, "카테고리: 카테고리명 형식이 올바르지 않습니다."),
+    CATEGORY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "카테고리: 이미 삭제된 카테고리입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/community/soap/catalog/domain/exception/CategoryException.java
+++ b/src/main/java/com/community/soap/catalog/domain/exception/CategoryException.java
@@ -1,0 +1,9 @@
+package com.community.soap.catalog.domain.exception;
+
+import com.community.soap.common.exception.AppException;
+
+public class CategoryException extends AppException {
+    public CategoryException(CategoryErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/community/soap/catalog/domain/exception/ProductErrorCode.java
+++ b/src/main/java/com/community/soap/catalog/domain/exception/ProductErrorCode.java
@@ -1,0 +1,32 @@
+package com.community.soap.catalog.domain.exception;
+
+import com.community.soap.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+    PRODUCT_INVALID(HttpStatus.BAD_REQUEST, "상품: 잘못된 상품 정보입니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품: 상품 정보를 찾을 수 없습니다."),
+    PRODUCT_NAME_DUPLICATED(HttpStatus.CONFLICT, "상품: 이미 사용 중인 상품명입니다."),
+    PRODUCT_NAME_INVALID(HttpStatus.BAD_REQUEST, "상품: 상품명 형식이 올바르지 않습니다."),
+
+    PRODUCT_STATUS_INVALID(HttpStatus.BAD_REQUEST, "상품: 상품 상태 값이 올바르지 않습니다."),
+    PRODUCT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "상품: 이미 삭제된 상품입니다."),
+
+    SKU_INVALID(HttpStatus.BAD_REQUEST, "상품: SKU 정보가 올바르지 않습니다."),
+    SKU_CODE_DUPLICATED(HttpStatus.CONFLICT, "상품: SKU 코드가 중복입니다."),
+    STOCK_INVALID(HttpStatus.BAD_REQUEST, "상품: 재고 수량이 올바르지 않습니다."),
+    STOCK_INSUFFICIENT(HttpStatus.CONFLICT, "상품: 재고가 부족합니다."),
+
+    CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "상품: 카테고리 정보가 올바르지 않습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "상품: 카테고리 정보를 찾을 수 없습니다."),
+    INVALID_PRICE_RANGE(HttpStatus.BAD_REQUEST, "상품: 잘못된 가격 범위입니다."),
+    PRODUCT_SOFT_DELETED(HttpStatus.BAD_REQUEST, "상품: 삭제된 상품입니다.");
+
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/community/soap/catalog/domain/exception/ProductException.java
+++ b/src/main/java/com/community/soap/catalog/domain/exception/ProductException.java
@@ -1,0 +1,9 @@
+package com.community.soap.catalog.domain.exception;
+
+import com.community.soap.common.exception.AppException;
+
+public class ProductException extends AppException {
+    public ProductException(ProductErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/community/soap/catalog/infrastructure/jpa/JpaCategoryAdapter.java
+++ b/src/main/java/com/community/soap/catalog/infrastructure/jpa/JpaCategoryAdapter.java
@@ -1,0 +1,9 @@
+package com.community.soap.catalog.infrastructure.jpa;
+
+import com.community.soap.catalog.application.port.out.CategoryRepositoryPort;
+import com.community.soap.catalog.domain.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCategoryAdapter extends JpaRepository<Category, Long>, CategoryRepositoryPort {
+
+}

--- a/src/main/java/com/community/soap/catalog/infrastructure/jpa/JpaProductAdapter.java
+++ b/src/main/java/com/community/soap/catalog/infrastructure/jpa/JpaProductAdapter.java
@@ -1,0 +1,100 @@
+package com.community.soap.catalog.infrastructure.jpa;
+
+import com.community.soap.catalog.application.port.out.ProductRepositoryPort;
+import com.community.soap.catalog.application.request.product.ProductSearchCondition;
+import com.community.soap.catalog.domain.entity.Product;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface JpaProductAdapter extends JpaRepository<Product, Long>, ProductRepositoryPort {
+
+    // SKU 중복(소프트삭제 제외)
+    @Query("select count(p) > 0 from Product p where p.sku.code = :code and p.isDeleted = false")
+    boolean existsBySkuCode(@Param("code") String code);
+
+    // === existsByProductId (소프트삭제 제외) ===
+    // 파생 쿼리로 간단/빠름
+    boolean existsByProductIdAndIsDeletedFalse(Long productId);
+
+    @Override
+    default boolean existsByProductId(Long productId) {
+        return existsByProductIdAndIsDeletedFalse(productId);
+    }
+
+    @Override
+    Optional<Product> findById(Long productId);
+
+    @Query(
+        value =
+            "SELECT p.* " +
+            "FROM s_product p " +
+            "WHERE p.is_deleted = false " +
+            "  AND p.product_status <> 'INACTIVE' " +
+            "  AND (:#{#cond.categoryId} IS NULL OR p.category_id = :#{#cond.categoryId}) " +
+            "  AND (:#{#cond.minPrice} IS NULL OR p.sku_price >= :#{#cond.minPrice}) " +   // <<< 변경
+            "  AND (:#{#cond.maxPrice} IS NULL OR p.sku_price <= :#{#cond.maxPrice}) " +   // <<< 변경
+            "  AND (:#{#cond.keyword} IS NULL OR :#{#cond.keyword} = '' " +
+            "       OR LOWER(p.name) LIKE CONCAT('%', LOWER(:#{#cond.keyword}), '%')) " +
+            "ORDER BY " +
+            "  CASE WHEN :sort = 'created_at' AND :dir = 'asc'  THEN p.created_at END ASC, " +
+            "  CASE WHEN :sort = 'created_at' AND :dir = 'desc' THEN p.created_at END DESC, " +
+            "  CASE WHEN :sort = 'name'       AND :dir = 'asc'  THEN p.name       END ASC, " +
+            "  CASE WHEN :sort = 'name'       AND :dir = 'desc' THEN p.name       END DESC, " +
+            "  CASE WHEN :sort = 'sku_price'  AND :dir = 'asc'  THEN p.sku_price  END ASC, " + // <<< 변경
+            "  CASE WHEN :sort = 'sku_price'  AND :dir = 'desc' THEN p.sku_price  END DESC, " + // <<< 변경
+            "  p.product_id DESC " +
+            "LIMIT :limit OFFSET :offset",
+        nativeQuery = true
+    )
+    List<Product> findAllByConditionRaw(
+        @Param("cond")  ProductSearchCondition condition,
+        @Param("sort")  String sort,   // created_at | name | sku_price
+        @Param("dir")   String dir,    // asc | desc
+        @Param("limit") int limit,
+        @Param("offset") int offset
+    );
+
+    @Query(
+        value =
+            "SELECT COUNT(*) " +
+            "FROM s_product p " +
+            "WHERE p.is_deleted = false " +
+            "  AND p.product_status <> 'INACTIVE' " +
+            "  AND (:#{#cond.categoryId} IS NULL OR p.category_id = :#{#cond.categoryId}) " +
+            "  AND (:#{#cond.minPrice} IS NULL OR p.sku_price >= :#{#cond.minPrice}) " + // <<< 변경
+            "  AND (:#{#cond.maxPrice} IS NULL OR p.sku_price <= :#{#cond.maxPrice}) " + // <<< 변경
+            "  AND (:#{#cond.keyword} IS NULL OR :#{#cond.keyword} = '' " +
+            "       OR LOWER(p.name) LIKE CONCAT('%', LOWER(:#{#cond.keyword}), '%'))",
+        nativeQuery = true
+    )
+    long countAllByCondition(@Param("cond") ProductSearchCondition condition);
+
+    @Override
+    default Page<Product> findAllByCondition(ProductSearchCondition condition, Pageable pageable) {
+        int page  = Math.max(0, pageable.getPageNumber());
+        int size  = pageable.getPageSize() <= 0 ? 20 : Math.min(pageable.getPageSize(), 200);
+        int limit = size;
+        int offset = page * size;
+
+        // 정렬 키 매핑: price -> sku_price
+        String sortToken = switch (condition.normalizedSort()) {
+            case "name" -> "name";
+            case "price" -> "sku_price";      // <<< 변경 포인트
+            case "createdAt" -> "created_at";
+            default -> "created_at";
+        };
+        String dir = condition.normalizedOrder(); // asc|desc
+
+        List<Product> rows = findAllByConditionRaw(condition, sortToken, dir, limit, offset);
+        long total = countAllByCondition(condition);
+
+        return new PageImpl<>(rows, PageRequest.of(page, size), total);
+    }
+}

--- a/src/main/java/com/community/soap/catalog/presentation/CategoryController.java
+++ b/src/main/java/com/community/soap/catalog/presentation/CategoryController.java
@@ -1,0 +1,92 @@
+package com.community.soap.catalog.presentation;
+
+import com.community.soap.catalog.application.port.in.CategoryUseCase;
+import com.community.soap.catalog.application.request.category.CreateCategoryRequest;
+import com.community.soap.catalog.application.request.category.UpdateCategoryRequest;
+import com.community.soap.catalog.application.response.category.CreateCategoryResponse;
+import com.community.soap.catalog.application.response.category.GetCategoriesResponse;
+import com.community.soap.catalog.application.response.category.UpdateCategoryResponse;
+import com.community.soap.common.aop.Permission;
+import com.community.soap.common.resolver.CurrentUser;
+import com.community.soap.common.resolver.CurrentUserInfo;
+import com.community.soap.common.util.PageResponse;
+import com.community.soap.user.domain.entity.UserRole;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/categories")
+@RestController
+public class CategoryController {
+
+    private final CategoryUseCase categoryUseCase;
+
+    @Permission(value = {UserRole.ADMIN, UserRole.MANAGER})
+    @PostMapping
+    public ResponseEntity<CreateCategoryResponse> createCategory(
+            @CurrentUser CurrentUserInfo info,
+            @RequestBody @Valid CreateCategoryRequest request
+    ) {
+        CreateCategoryResponse response = categoryUseCase.createCategory(info.userId(), request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    // GET /api/v1/categories?page=0&size=8&sort=createdAt,desc
+    // GET /api/v1/categories?all=true
+    // GET /api/v1/categories?q=soap&page=0&size=8
+    @GetMapping
+    public ResponseEntity<PageResponse<GetCategoriesResponse>> getCategories(
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "false") boolean all,
+            @ParameterObject @PageableDefault(size = 8, sort = "createdAt", direction = org.springframework.data.domain.Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        PageResponse<GetCategoriesResponse> res = categoryUseCase.getCategories(q, pageable, all);
+        return ResponseEntity.ok(res);
+    }
+
+    @Permission(value = {UserRole.ADMIN, UserRole.MANAGER})
+    @PatchMapping("/{categoryId}")
+    public ResponseEntity<UpdateCategoryResponse> updateCategory(
+            @CurrentUser CurrentUserInfo info,
+            @PathVariable Long categoryId,
+            @RequestBody UpdateCategoryRequest request
+    ) {
+        UpdateCategoryResponse response = categoryUseCase.updateCategory(info.userId(), categoryId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @Permission(value = {UserRole.ADMIN, UserRole.MANAGER})
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<Void> softDeleteCategory(
+            @CurrentUser CurrentUserInfo info,
+            @PathVariable Long categoryId
+    ) {
+        categoryUseCase.softDeleteCategory(info.userId(), categoryId);
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+}

--- a/src/main/java/com/community/soap/catalog/presentation/ProductController.java
+++ b/src/main/java/com/community/soap/catalog/presentation/ProductController.java
@@ -9,6 +9,7 @@ import com.community.soap.catalog.application.request.product.UpdateProductReque
 import com.community.soap.catalog.application.response.product.CreateProductResponse;
 import com.community.soap.catalog.application.response.product.GetProductResponse;
 import com.community.soap.common.util.PageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -75,7 +76,7 @@ public class ProductController {
     @PatchMapping("/{productId}/increase")
     public ResponseEntity<GetProductResponse> increaseProduct(
             @PathVariable Long productId,
-            @RequestBody IncreaseProductRequest request
+            @RequestBody @Valid IncreaseProductRequest request
     ) {
         GetProductResponse response = productUseCase.increaseProduct(productId, request);
 
@@ -111,7 +112,7 @@ public class ProductController {
     @DeleteMapping("/{productId}/delete")
     public ResponseEntity<GetProductResponse> softDeleteProduct(
             @PathVariable Long productId,
-            @RequestBody UpdateProductRequest request
+            @RequestBody @Valid UpdateProductRequest request
     ) {
         productUseCase.softDeleteProduct(productId, request);
 

--- a/src/main/java/com/community/soap/catalog/presentation/ProductController.java
+++ b/src/main/java/com/community/soap/catalog/presentation/ProductController.java
@@ -1,0 +1,124 @@
+package com.community.soap.catalog.presentation;
+
+import com.community.soap.catalog.application.port.in.ProductUseCase;
+import com.community.soap.catalog.application.request.product.CreateProductRequest;
+import com.community.soap.catalog.application.request.product.DecreaseProductRequest;
+import com.community.soap.catalog.application.request.product.IncreaseProductRequest;
+import com.community.soap.catalog.application.request.product.ProductSearchCondition;
+import com.community.soap.catalog.application.request.product.UpdateProductRequest;
+import com.community.soap.catalog.application.response.product.CreateProductResponse;
+import com.community.soap.catalog.application.response.product.GetProductResponse;
+import com.community.soap.common.util.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+@RestController
+public class ProductController {
+
+    private final ProductUseCase productUseCase;
+
+
+    @PostMapping
+    public ResponseEntity<CreateProductResponse> createProduct(
+            @RequestBody CreateProductRequest request
+    ) {
+        CreateProductResponse response = productUseCase.createProduct(request);
+
+        return ResponseEntity.
+                status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<GetProductResponse> getProductDetail(
+            @PathVariable Long productId
+    ) {
+        GetProductResponse response = productUseCase.getProductDetail(productId);
+
+        return ResponseEntity.
+                status(HttpStatus.OK)
+                .body(response);
+    }
+
+
+    @GetMapping
+    public ResponseEntity<PageResponse<GetProductResponse>> getProducts(
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) Integer minPrice,
+            @RequestParam(required = false) Integer maxPrice,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "createdAt") String sort,
+            @RequestParam(defaultValue = "desc") String order,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "20") Integer size
+    ) {
+        ProductSearchCondition condition = new ProductSearchCondition(
+                categoryId, minPrice, maxPrice, keyword, sort, order, page, size);
+        PageResponse<GetProductResponse> response = productUseCase.getProducts(condition);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @PatchMapping("/{productId}/increase")
+    public ResponseEntity<GetProductResponse> increaseProduct(
+            @PathVariable Long productId,
+            @RequestBody IncreaseProductRequest request
+    ) {
+        GetProductResponse response = productUseCase.increaseProduct(productId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @PatchMapping("/{productId}/decrease")
+    public ResponseEntity<GetProductResponse> decreaseProduct(
+            @PathVariable Long productId,
+            @RequestBody DecreaseProductRequest request
+    ) {
+        GetProductResponse response = productUseCase.decreaseProduct(productId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @PatchMapping("/{productId}/update")
+    public ResponseEntity<GetProductResponse> updateProduct(
+            @PathVariable Long productId,
+            @RequestBody UpdateProductRequest request
+    ) {
+        GetProductResponse response = productUseCase.updateProduct(productId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @DeleteMapping("/{productId}/delete")
+    public ResponseEntity<GetProductResponse> softDeleteProduct(
+            @PathVariable Long productId,
+            @RequestBody UpdateProductRequest request
+    ) {
+        productUseCase.softDeleteProduct(productId, request);
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/community/soap/common/aop/Permission.java
+++ b/src/main/java/com/community/soap/common/aop/Permission.java
@@ -7,11 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Permission {
-    UserRole[] value() default {
-            UserRole.ADMIN,
-            UserRole.MANAGER,
-            UserRole.USER
-    };
+    UserRole[] value() default {}; // 기본은 "아무 역할도 허용 X"가 아니라 "명시적으로만 체크" 용도
 }

--- a/src/main/java/com/community/soap/common/aop/PermissionAspect.java
+++ b/src/main/java/com/community/soap/common/aop/PermissionAspect.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -23,29 +24,41 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Component
 public class PermissionAspect {
 
-    @Before("@annotation(permission)")
-    public void permission(JoinPoint joinPoint, Permission permission) {
-        Set<UserRole> allowed = Arrays.stream(permission.value()).collect(Collectors.toSet());
+    @Before("@within(com.community.soap.common.aop.Permission) || @annotation(com.community.soap.common.aop.Permission)")
+    public void permission(JoinPoint jp) {
+        Permission perm = resolvePermission(jp);
+        if (perm == null) return; // 애너테이션이 아예 없으면 권한 체크 생략
+
         UserRole current = currentUserRoleOr401();
 
+        UserRole[] required = perm.value();
+        if (required.length == 0) {
+            // 애너테이션은 있으나 값이 비어있으면 "로그인만 강제"로 처리 (403 체크 X)
+            return;
+        }
+
+        Set<UserRole> allowed = Arrays.stream(required).collect(Collectors.toSet());
         if (!allowed.contains(current)) {
             log.info("권한 거부: 현재 역할={}, 허용 역할={}", current, allowed);
-            throw new AppException(CommonErrorCode.FORBIDDEN);
+            throw new AppException(CommonErrorCode.FORBIDDEN); // 403
         }
     }
 
+    private Permission resolvePermission(JoinPoint jp) {
+        MethodSignature sig = (MethodSignature) jp.getSignature();
+        Permission method = sig.getMethod().getAnnotation(Permission.class);
+        if (method != null) return method;
+        return jp.getTarget().getClass().getAnnotation(Permission.class);
+    }
+
     private UserRole currentUserRoleOr401() {
-        ServletRequestAttributes attrs =
-                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        if (attrs == null) {
-            log.warn("ServletRequestAttributes is null");
-            throw new AppException(CommonErrorCode.UNAUTHORIZED);
-        }
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs == null) throw new AppException(CommonErrorCode.UNAUTHORIZED);
         HttpServletRequest req = attrs.getRequest();
 
         Object roleAttr = req.getAttribute(ATTR_USER_ROLE);
         if (!(roleAttr instanceof UserRole role)) {
-            log.warn("요청에 역할 attribute가 없습니다: {}", ATTR_USER_ROLE);
+            // 토큰 없음/무효 등으로 역할이 없는 경우
             throw new AppException(CommonErrorCode.UNAUTHORIZED);
         }
         return role;

--- a/src/main/java/com/community/soap/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/community/soap/common/filter/JwtAuthenticationFilter.java
@@ -24,12 +24,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPatternParser;
 
-/**
- * - excludePaths, excludeMethods 기반으로 인증 제외
- * - Authorization 헤더의 Bearer 토큰 또는 쿠키에서 액세스 토큰 추출
- * - 토큰에서 userId/role 파싱 후 request attribute 로 저장
- * - 예외는 던지고, 상위 ExceptionHandlingFilter 가 처리
- */
 @Slf4j(topic = "JwtAuthenticationFilter")
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -47,9 +41,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 .toList();
     }
 
-    /**
-     * "/**"의 base, 트레일링 슬래시 제거 변형을 함께 등록해 오탐/미탐을 방지
-     */
     private Stream<String> expandPatternVariants(String raw) {
         Stream<String> s = Stream.of(raw);
         if (raw.endsWith("/**")) {
@@ -63,15 +54,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        // 1) 메서드 제외 (기본 OPTIONS)
-        if (props.getExcludeMethods().stream()
-                .anyMatch(m -> m.equalsIgnoreCase(request.getMethod()))) {
-            return true;
-        }
-        // 2) 경로 제외
-        String stripped = stripContextPath(request.getRequestURI(), request.getContextPath());
-        PathContainer container = PathContainer.parsePath(stripped);
-        return excludePatterns.stream().anyMatch(p -> p.matches(container));
+        return false; // 항상 실행
     }
 
     private String stripContextPath(String uri, String ctx) {
@@ -81,74 +64,91 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return uri.startsWith(ctx) ? uri.substring(ctx.length()) : uri;
     }
 
-    @Override
-    protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain
-    ) throws ServletException, IOException {
+    private boolean isExcluded(HttpServletRequest request) {
+        if (props.getExcludeMethods().stream()
+                .anyMatch(m -> m.equalsIgnoreCase(request.getMethod()))) {
+            return true;
+        }
+        String stripped = stripContextPath(request.getRequestURI(), request.getContextPath());
+        PathContainer container = PathContainer.parsePath(stripped);
+        return excludePatterns.stream().anyMatch(p -> p.matches(container));
+    }
 
-        // 여기까지 왔다는 건 shouldNotFilter=false → 인증 필요
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain chain)
+            throws ServletException, IOException {
+
+        boolean excluded = isExcluded(request);
         String accessToken = resolveAccessToken(request);
+
         if (!StringUtils.hasText(accessToken)) {
-            throw new AppException(CommonErrorCode.INVALID_HEADER); // Authorization/Cookie 둘 다 없음
+            if (excluded) { // 공개 경로: 토큰 없어도 통과
+                chain.doFilter(request, response);
+                return;
+            }
+            throw new AppException(CommonErrorCode.INVALID_HEADER); // 비공개 경로: 401
         }
 
         try {
             Long userId = jwtProvider.getUserId(accessToken);
             String roleStr = jwtProvider.getUserRole(accessToken);
+            UserRole role = resolveRole(roleStr); // ← 여기서 ROLE_ 접두사/대소문자 정규화
 
-            if (userId == null || !StringUtils.hasText(roleStr)) {
-                throw new AppException(CommonErrorCode.INVALID_TOKEN);
-            }
-
-            UserRole role;
-            try {
-                role = UserRole.valueOf(roleStr.trim().toUpperCase(Locale.ROOT));
-            } catch (IllegalArgumentException e) {
-                throw new AppException(CommonErrorCode.INVALID_ROLE_BY_TOKEN);
-            }
-
-            // 컨트롤러/리졸버/Aspect에서 공통으로 쓰는 키로 저장
             request.setAttribute(ATTR_USER_ID, userId);
             request.setAttribute(ATTR_USER_ROLE, role);
 
+            if (log.isDebugEnabled()) {
+                log.debug("JWT OK -> userId={}, role={}", userId, role);
+            }
         } catch (AppException e) {
-            // AppException은 그대로 전파 (ExceptionHandlingFilter가 응답 작성)
-            throw e;
-        } catch (Exception e) {
-            // 그 외는 일반 토큰 오류로 통일
-            throw new AppException(CommonErrorCode.INVALID_TOKEN);
+            if (excluded) { // 공개 경로: 토큰이 이상해도 인증 강요하지 않음(속성 미세팅 상태로 통과)
+                chain.doFilter(request, response);
+                return;
+            }
+            throw e; // 비공개 경로: 401
         }
 
-        filterChain.doFilter(request, response);
+        chain.doFilter(request, response);
     }
 
-    /**
-     * Authorization 헤더(Bearer …) 우선, 없으면 쿠키(props.accessTokenCookie)에서 조회. "Bearer" 접두사는 대소문자 무시 +
-     * 앞뒤 공백 허용.
-     */
     private String resolveAccessToken(HttpServletRequest request) {
         String auth = request.getHeader("Authorization");
         if (StringUtils.hasText(auth)) {
             String candidate = auth.trim();
-            // "Bearer " 접두어 대소문자 무시
             if (candidate.regionMatches(true, 0, "Bearer ", 0, 7)) {
                 return candidate.substring(7).trim();
             }
-            // 접두어가 없으면 아예 토큰으로 보지 않고 INVALID_TOKEN 처리하도록 null 반환
-            return null;
+            return null; // Bearer 접두사 없으면 무효로 간주
         }
 
-        // 헤더가 없다면 쿠키 fallback
-        String cookieName = props.getAccessTokenCookie();
-        if (request.getCookies() != null && StringUtils.hasText(cookieName)) {
-            for (Cookie c : request.getCookies()) {
-                if (cookieName.equals(c.getName()) && StringUtils.hasText(c.getValue())) {
-                    return c.getValue().trim();
+        // 쿠키 폴백은 설정 켜졌을 때만
+        if (props.isCookieFallbackEnabled()) {
+            String cookieName = props.getAccessTokenCookie();
+            if (request.getCookies() != null && StringUtils.hasText(cookieName)) {
+                for (Cookie c : request.getCookies()) {
+                    if (cookieName.equals(c.getName()) && StringUtils.hasText(c.getValue())) {
+                        return c.getValue().trim();
+                    }
                 }
             }
         }
         return null;
+    }
+
+    // <-- 질문하신 이 부분!
+    private UserRole resolveRole(String roleStr) {
+        if (!StringUtils.hasText(roleStr)) {
+            throw new AppException(CommonErrorCode.INVALID_TOKEN);
+        }
+        String normalized = roleStr.trim().toUpperCase(Locale.ROOT);
+        if (normalized.startsWith("ROLE_")) {
+            normalized = normalized.substring(5); // ROLE_ADMIN -> ADMIN
+        }
+        try {
+            return UserRole.valueOf(normalized);
+        } catch (IllegalArgumentException e) {
+            throw new AppException(CommonErrorCode.INVALID_ROLE_BY_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/community/soap/common/util/PageResponse.java
+++ b/src/main/java/com/community/soap/common/util/PageResponse.java
@@ -1,0 +1,32 @@
+package com.community.soap.common.util;
+
+import com.community.soap.catalog.application.response.category.GetCategoriesResponse;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
+
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return PageResponse.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .last(page.isLast())
+                .build();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,8 @@ security:
       - /api/v1/auth/token/refresh
       - /api/v1/auth/email/request-verification-code
       - /api/v1/auth/email/verify-code
+      - /api/v1/categories/**
+      - /api/v1/products/**
     exclude-methods:
       - OPTIONS
     access-token-cookie: null
@@ -73,3 +75,9 @@ auth:
     max-attempts: 5                     # 최대 인증 시도
     block-ttl: 10m                      # 시도 초과 차단 시간
     verified-ttl: 10m                   # 검증 성공 플래그 TTL
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.hibernate.orm.jdbc.extract: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
         format_sql: true
         show_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
-        open-in-view: false
+    open-in-view: false
 
   data:
     redis:
@@ -27,8 +27,8 @@ spring:
   jwt:
     secret-access: ${ACCESS_SECRET}
     secret-refresh: ${REFRESH_SECRET}
-    access-token-expiration: ${ACCESS-TOKEN-EXPIRATION}
-    refresh-token-expiration: ${REFRESH-TOKEN-EXPIRATION}
+    access-token-expiration: ${ACCESS_TOKEN_EXPIRATION}
+    refresh-token-expiration: ${REFRESH_TOKEN_EXPIRATION}
 
   mail:
     host: smtp.naver.com

--- a/src/test/java/com/community/soap/catalog/http/category-service-request.http
+++ b/src/test/java/com/community/soap/catalog/http/category-service-request.http
@@ -1,0 +1,38 @@
+### user-service: 회원가입
+POST http://localhost:8080/api/v1/auth/signup
+Content-Type: application/json
+
+{
+  "email": "test@gmail.com",
+  "password": "TESTpw12!",
+  "nickname": "testNickname"
+}
+
+> {%
+  client.global.set("email", response.body.email)
+%}
+
+### user-service: 로그인
+POST http://localhost:8080/api/v1/auth/sign-in
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "TESTpw12!"
+}
+
+> {%
+  client.global.set("userId", response.body.userId.toFixed(0))
+  client.global.set("accessToken", response.body.accessToken)
+  client.global.set("refreshToken", response.body.refreshToken)
+%}
+
+### 카테고리 생성
+POST http://localhost:8080/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "name": "testCategory",
+  "description": "testDescription"
+}

--- a/src/test/java/com/community/soap/catalog/http/product-service-request.http
+++ b/src/test/java/com/community/soap/catalog/http/product-service-request.http
@@ -1,0 +1,172 @@
+### user-service: 회원가입 (옵션)
+POST http://localhost:8080/api/v1/auth/signup
+Content-Type: application/json
+
+{
+  "email": "test@gmail.com",
+  "password": "TESTpw12!",
+  "nickname": "testNickname"
+}
+
+> {%
+  client.global.set("email", response.body.email)
+%}
+
+### user-service: 로그인
+POST http://localhost:8080/api/v1/auth/sign-in
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "TESTpw12!"
+}
+
+> {%
+  client.global.set("userId", response.body.userId?.toFixed ? response.body.userId.toFixed(0) : String(response.body.userId))
+  client.global.set("accessToken", response.body.accessToken)
+  client.global.set("refreshToken", response.body.refreshToken)
+%}
+
+
+### catalog: 상품 생성 (성공)
+POST http://localhost:8080/api/v1/products
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "name": "testProduct",
+  "description": "testProduct",
+  "categoryId": 10,
+  "productStatus": "ACTIVE",
+  "skuCode": "testCode-001",
+  "price": 4500,
+  "stock": 120
+}
+
+> {%
+  client.global.set("productId", response.body.productId.toFixed(0))
+%}
+
+
+### catalog: 상품 상세 조회
+GET http://localhost:8080/api/v1/products/{{productId}}
+Content-Type: application/json
+
+{
+}
+
+### catalog: 상품 목록 - 기본(최신순)
+GET http://localhost:8080/api/v1/products?sort=createdAt&order=desc&page=0&size=20
+Content-Type: application/json
+
+
+### catalog: 상품 목록 - 필터 조합 (카테고리 + 가격 범위 + 키워드)
+GET http://localhost:8080/api/v1/products?categoryId=10&minPrice=1000&maxPrice=5000&keyword=test&sort=createdAt&order=desc&page=0&size=20
+Content-Type: application/json
+
+
+### catalog: 상품 목록 - 가격 오름차순
+GET http://localhost:8080/api/v1/products?sort=price&order=asc&page=0&size=20
+Content-Type: application/json
+
+
+### catalog: 상품 목록 - 이름 내림차순
+GET http://localhost:8080/api/v1/products?sort=name&order=desc&page=0&size=20
+Content-Type: application/json
+
+
+### catalog: 상품 생성 - SKU 중복 에러 확인 (예상: 409/400 정책에 따라 다름)
+POST http://localhost:8080/api/v1/products
+Content-Type: application/json
+
+{
+  "name": "testProduct-dup",
+  "description": "dup",
+  "categoryId": 10,
+  "productStatus": "ACTIVE",
+  "skuCode": "testCode-001",
+  "price": 4500,
+  "stock": 10
+}
+
+
+### catalog: 상품 목록 - 잘못된 가격 범위 (예상: 400 INVALID_PRICE_RANGE)
+GET http://localhost:8080/api/v1/products?minPrice=10000&maxPrice=100
+Content-Type: application/json
+
+
+### catalog: 상품 부분 업데이트(PATCH) - 이름만 변경
+PATCH http://localhost:8080/api/v1/products/{{productId}}/update
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "name": "testProduct-renamed"
+}
+
+
+### catalog: 상품 부분 업데이트(PATCH) - 가격/재고만 변경
+PATCH http://localhost:8080/api/v1/products/{{productId}}/update
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "price": 5500,
+  "stock": 150
+}
+
+
+### catalog: 상품 부분 업데이트(PATCH) - SKU 코드 변경 (성공 케이스)
+PATCH http://localhost:8080/api/v1/products/{{productId}}/update
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "skuCode": "testCode-002"
+}
+
+
+### 준비: 다른 상품 생성 (SKU 중복 테스트용 대상)
+POST http://localhost:8080/api/v1/products
+Content-Type: application/json
+
+{
+  "name": "anotherProduct",
+  "description": "for-dup-test",
+  "categoryId": 10,
+  "productStatus": "ACTIVE",
+  "skuCode": "testCode-003",
+  "price": 3000,
+  "stock": 10
+}
+
+> {%
+  client.global.set("otherProductId", String(response.body.productId))
+%}
+
+
+### catalog: 다른 상품의 SKU를 우리가 바꾸려는 코드로 세팅하여, 이후 중복 상황 유도
+PATCH http://localhost:8080/api/v1/products/{{otherProductId}}/update
+Content-Type: application/json
+
+{
+  "skuCode": "testCode-004"
+}
+
+
+### catalog: 원래 상품을 중복 SKU로 변경 시도 (예상: 409/400 SKU_CODE_DUPLICATED)
+PATCH http://localhost:8080/api/v1/products/{{productId}}/update
+Content-Type: application/json
+
+{
+  "skuCode": "testCode-004"
+}
+
+### (선택) 비활성 이후 수량 증가 시도 (예상: 업데이트 불가 에러)
+PUT http://localhost:8080/api/v1/products/{{productId}}/increase
+Content-Type: application/json
+
+{
+  "quantity": 1
+}
+


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- 상품과 카테고리 CRUD 구현

## 🔍 관련 이슈
- Closes #33

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 카테고리 및 상품 도메인: 생성/조회(검색·필터·정렬·페이징/전체)/수정/재고증감/소프트삭제 REST API 및 서비스/응답 DTO 추가
  - API 응답의 페이지 래퍼 표준화 및 OpenAPI 기반 문서 UI 제공
- **Security**
  - 권한 검사 범위 확장(클래스/메서드) 및 JWT 처리/역할 파싱 개선, 카테고리·상품 공개 조회 허용
- **Documentation**
  - REST Docs 빌드 작업(스니펫 → 문서) 통합
- **Chores**
  - SQL 및 JDBC 로깅 강화
- **Tests**
  - 인증 및 카테고리/상품 E2E HTTP 테스트 시나리오 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->